### PR TITLE
Publish v0.0.1 to GitHub Releases with corrected workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,8 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
+  packages: write
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -6,28 +6,34 @@ Existing SQL formatters can't be configured to enforce a specific team style, an
 
 ## Quick start
 
-No installation required. Run directly with [`uvx`](https://docs.astral.sh/uv/guides/tools/):
+No installation required. Run directly with [`uvx`](https://docs.astral.sh/uv/guides/tools/).
+
+### From a GitHub Release (recommended)
+
+Releases publish a pre-built wheel to the [Releases page](https://github.com/amfaro/jarify/releases). Pinning to a wheel is the fastest option because uv skips the build step:
+
+```bash
+uvx --from "https://github.com/amfaro/jarify/releases/download/v0.0.1/jarify-0.0.1-py3-none-any.whl" jarify fmt path/to/query.sql
+```
+
+### From git
+
+Always runs the latest commit on `main` — useful during development:
 
 ```bash
 uvx --from git+https://github.com/amfaro/jarify.git jarify fmt path/to/query.sql
 ```
 
-Pin to a specific release:
+Pin to a specific release tag:
 
 ```bash
-uvx --from "git+https://github.com/amfaro/jarify.git@v0.1.0" jarify fmt path/to/query.sql
-```
-
-Or install from a release wheel for faster repeat invocations:
-
-```bash
-uvx --from "https://github.com/amfaro/jarify/releases/download/v0.1.0/jarify-0.1.0-py3-none-any.whl" jarify fmt path/to/query.sql
+uvx --from "git+https://github.com/amfaro/jarify.git@v0.0.1" jarify fmt path/to/query.sql
 ```
 
 ### Persistent install
 
 ```bash
-uv tool install "git+https://github.com/amfaro/jarify.git"
+uv tool install "https://github.com/amfaro/jarify/releases/download/v0.0.1/jarify-0.0.1-py3-none-any.whl"
 jarify fmt path/to/query.sql
 ```
 
@@ -185,9 +191,9 @@ mise run check   # lint + test
 
 ### Releases
 
-Push a `v*` tag to trigger the publish workflow. GitHub Actions builds the wheel and sdist and attaches them to a GitHub Release.
+Push a `v*` tag to trigger the publish workflow. GitHub Actions builds the wheel and sdist, attaches them to a GitHub Release, and generates release notes automatically.
 
 ```bash
-git tag v0.2.0
-git push origin v0.2.0
+git tag v0.0.1
+git push origin v0.0.1
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jarify"
-version = "0.1.0"
+version = "0.0.1"
 description = "Bespoke SQL linter and formatter for DuckDB, powered by sqlglot"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

First release prep for `v0.0.1`. Three focused changes:

- **Version bump** — `pyproject.toml` version changed from `0.1.0` to `0.0.1` to match the intended first tag
- **Workflow permissions** — `publish.yml` corrected from `contents: read` to `contents: write`; `packages: write` added for future use. The app token was compensating for the wrong declaration, but the job-level permissions should be accurate
- **README quick-start rewrite** — leads with the GitHub Releases wheel URL (fastest `uvx` invocation, no build step), followed by the `git+https@tag` pin form, and a persistent install example using the wheel URL; Releases section updated with `v0.0.1` tag and a note about auto-generated notes

> **Note on GitHub Packages:** GitHub Packages does not support a Python/PyPI registry. GitHub Releases with attached wheel/sdist assets is the correct distribution mechanism for Python packages on GitHub, and is what this workflow produces.

## After merge

Tag `v0.0.1` on `main` to trigger the publish workflow:

```bash
git tag v0.0.1
git push origin v0.0.1
```

Resolves #4
