### PR TITLE
Commit uv.lock after version bump to 0.0.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "jarify"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Commits `uv.lock` after the `pyproject.toml` version bump from `0.1.0` to `0.0.1`. The file was updated locally but not staged, leaving the lockfile out of sync with the declared version.

Resolves #8
