### PR TITLE
Upgrade actions/create-github-app-token from @v1 to @v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.WORKFLOW_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOW_CLIENT_PRIVATE_KEY }}


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Bumps `actions/create-github-app-token` from `@v1` to `@v2` in `.github/workflows/publish.yml`.

`@v1` runs on Node.js 20, which GitHub Actions will deprecate on June 2, 2026 and remove entirely on September 16, 2026. This upgrade resolves the deprecation warning seen in the failing publish run.

Resolves #7
