### PR TITLE
Wire publish workflow secrets through Doppler

### DIFF
--- a/.doppler.yaml
+++ b/.doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  project: jarify
+  config: ci


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

The `publish` workflow fails immediately because `secrets.WORKFLOW_CLIENT_ID` and `secrets.WORKFLOW_CLIENT_PRIVATE_KEY` are not set — `actions/create-github-app-token` can't generate a token without them.

This PR adds `.doppler.yaml` pointing to the `jarify/ci` config (Doppler project created as part of this work). Once the two manual steps below are completed, the secrets will flow into GitHub automatically and the publish workflow will succeed.

## Manual follow-up in Doppler

1. Add `WORKFLOW_CLIENT_ID` and `WORKFLOW_CLIENT_PRIVATE_KEY` to the `jarify` → `ci` config.
2. Configure a Doppler GitHub sync from `jarify/ci` to the `amfaro/jarify` repository secrets.

No workflow changes are required — the existing `secrets.WORKFLOW_CLIENT_ID` / `secrets.WORKFLOW_CLIENT_PRIVATE_KEY` references will resolve once the sync is active.

Resolves #6
