### PR TITLE
Fetch publish secrets from Doppler shared/prod

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,19 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
+      - name: Fetch secrets from Doppler
+        uses: dopplerhq/secrets-fetch-action@v1
+        id: doppler
+        with:
+          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          inject-env-vars: false
+
       - name: Generate token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.WORKFLOW_CLIENT_ID }}
-          private-key: ${{ secrets.WORKFLOW_CLIENT_PRIVATE_KEY }}
+          app-id: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_ID }}
+          private-key: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Replaces the missing `secrets.WORKFLOW_CLIENT_ID` / `secrets.WORKFLOW_CLIENT_PRIVATE_KEY` GitHub secrets with a single `DOPPLER_TOKEN`, fetching the actual values from `shared/prod` at runtime using `dopplerhq/secrets-fetch-action@v1`.

## How it works

1. `Fetch secrets from Doppler` — authenticates with `DOPPLER_TOKEN` and pulls `WORKFLOW_CLIENT_ID` + `WORKFLOW_CLIENT_PRIVATE_KEY` from the `shared/prod` config.
2. `Generate token` — passes those values to `actions/create-github-app-token@v2` exactly as before.

The rest of the workflow is unchanged.

## One manual step required

Create a Doppler service token scoped to `shared/prod` and add it as `DOPPLER_TOKEN` to the `amfaro/jarify` repository secrets:

```
doppler configs tokens create --project shared --config prod --name jarify-publish
# copy the token → GitHub repo Settings → Secrets → New repository secret → DOPPLER_TOKEN
```

Resolves #6
