### PR TITLE
fix(publish): pin dopplerhq/secrets-fetch-action to v2.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Fetch secrets from Doppler
-        uses: dopplerhq/secrets-fetch-action@v2
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
         id: doppler
         with:
           doppler-token: ${{ secrets.DOPPLER_TOKEN }}


### PR DESCRIPTION
No v2 alias. Full semver required.