### PR TITLE
fix(publish): add doppler-project and doppler-config inputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
         id: doppler
         with:
           doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-project: shared
+          doppler-config: prod
           inject-env-vars: false
 
       - name: Generate token


### PR DESCRIPTION
Service Account token needs explicit project+config. Adding shared/prod.