### PR TITLE
feat: rewrite SELECT * as FROM-first DuckDB syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## What this project is
+
+Jarify is a SQL formatter and linter for DuckDB, built on [sqlglot](https://github.com/tobymao/sqlglot). It parses SQL with the DuckDB dialect and rewrites it through an opinionated, non-configurable style.
+
+## Dev setup
+
+Requires [mise](https://mise.jdx.dev) and [uv](https://docs.astral.sh/uv/).
+
+```bash
+uv sync --all-groups
+```
+
+## Common tasks
+
+| Task | Command |
+|------|---------|
+| Run tests | `mise run test` |
+| Run linter | `mise run lint` |
+| Run both | `mise run check` |
+| Format source | `mise run fmt` |
+
+Always run `mise run check` before committing and ensure all tests pass.
+
+## Adding or changing a rule
+
+1. **Formatting rules** live in `src/jarify/generator.py` (override a generator method) or `src/jarify/rules/` (subclass `FormatterRule` and implement `apply()`).
+2. **Lint-only rules** live in `src/jarify/rules/` (implement `check()`, leave `apply()` as a no-op).
+3. Register new rules in `src/jarify/rules/__init__.py` and add a config knob to `src/jarify/config.py`.
+4. Add a fixture pair in `tests/fixtures/<category>/` and unit tests in `tests/`.
+5. **Document every new or changed rule in [`docs/sql-style-guide.md`](docs/sql-style-guide.md)** with a bad/good SQL example.
+
+## Adding fixture tests
+
+```bash
+# 1. Create the input file
+echo "SELECT a, b FROM t" > tests/fixtures/<category>/<name>.input.sql
+
+# 2. Generate the expected output
+uv run pytest tests/test_fixtures.py --update-fixtures
+
+# 3. Review the generated .expected.sql, then commit both files
+```

--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -189,8 +189,6 @@ WITH _latest_version AS
 (
   ...
 )
-SELECT
-   *
 FROM _latest_version
 ;
 ```
@@ -312,6 +310,37 @@ SELECT
   ,b::TEXT
   ,c::BOOLEAN
 FROM t
+;
+```
+
+---
+
+### `SELECT *` — rewritten as FROM-first
+
+`SELECT *` is rewritten to DuckDB's FROM-first syntax, omitting the `SELECT` clause entirely. Applies only when there are no JOINs.
+
+**Bad**
+```sql
+SELECT
+   *
+FROM people
+;
+```
+
+**Good**
+```sql
+FROM people
+;
+```
+
+Also applies with `WHERE`, `ORDER BY`, `LIMIT`, etc.:
+
+```sql
+FROM orders
+WHERE
+  status = 'active'
+ORDER BY
+   created_at
 ;
 ```
 

--- a/src/jarify/config.py
+++ b/src/jarify/config.py
@@ -30,6 +30,7 @@ class JarifyConfig:
     normalize_join: bool = True  # bare JOIN → INNER JOIN
     require_alias_as: bool = True  # always require AS keyword for aliases
     one_column_per_line: bool = True  # each SELECT column on its own line
+    prefer_from_first: bool = True  # SELECT * FROM t → FROM t (DuckDB FROM-first syntax)
 
     # --- general lint rules (severity: "off" | "warn" | "error") ---
     no_select_star: str = "warn"

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -9,11 +9,12 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - Consistent keyword casing; DuckDB functions in lowercase
 - IS NOT NULL preserved (not rewritten to NOT x IS NULL)
 - NULLS LAST/FIRST suppressed when it matches DuckDB's default
-- Column aliases aligned on AS when 2+ aliases exist in a SELECT
+- SELECT * FROM t → FROM t (DuckDB FROM-first syntax)
 """
 
 from __future__ import annotations
 
+import re
 import typing as t
 from typing import TYPE_CHECKING, ClassVar
 
@@ -233,6 +234,27 @@ class JarifyGenerator(DuckDB.Generator):
     # ------------------------------------------------------------------
     # format_args: apply leading-comma style when function args wrap
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # FROM-first: SELECT * FROM t → FROM t
+    # ------------------------------------------------------------------
+
+    def select_sql(self, expression: exp.Select) -> str:
+        exprs = expression.expressions
+        if (
+            self._config.prefer_from_first
+            and len(exprs) == 1
+            and isinstance(exprs[0], exp.Star)
+            and not expression.args.get("distinct")
+            and not expression.args.get("joins")
+        ):
+            expr_copy = expression.copy()
+            expr_copy.set("expressions", [])
+            sql = super().select_sql(expr_copy)
+            # Strip the bare "SELECT" line (no columns → "SELECT\nFROM ...")
+            # Uses multiline ^ so indented "  SELECT" inside CTEs is never matched.
+            return re.sub(r"(?m)^SELECT\n", "", sql)
+        return super().select_sql(expression)
 
     # ------------------------------------------------------------------
     # Cast: prefer :: shorthand over CAST()

--- a/tests/fixtures/complex/real_world.expected.sql
+++ b/tests/fixtures/complex/real_world.expected.sql
@@ -15,8 +15,6 @@ WITH _latest_version AS
 )
 ,_relevant_skus AS
 (
-  SELECT
-     *
   FROM read_parquet(
      's3://' || getvariable('tigris_bucket') || '/dataops/*/*/relevant_skus.parquet'
     ,hive_partitioning = TRUE
@@ -27,8 +25,6 @@ WITH _latest_version AS
 )
 ,_enrollments AS
 (
-  SELECT
-     *
   FROM read_parquet(
      's3://' || getvariable('tigris_bucket') || '/dataops/*/*/enrollments.parquet'
     ,hive_partitioning = TRUE

--- a/tests/fixtures/duckdb/pivot.expected.sql
+++ b/tests/fixtures/duckdb/pivot.expected.sql
@@ -1,5 +1,3 @@
-SELECT
-   *
 FROM t
 PIVOT(sum(amount) FOR  category IN ( 'A'
     ,'B'

--- a/tests/fixtures/duckdb/read_parquet.expected.sql
+++ b/tests/fixtures/duckdb/read_parquet.expected.sql
@@ -1,5 +1,3 @@
-SELECT
-   *
 FROM read_parquet('data.parquet')
 WHERE
   year = 2024

--- a/tests/fixtures/select/from_first.expected.sql
+++ b/tests/fixtures/select/from_first.expected.sql
@@ -1,0 +1,12 @@
+FROM people
+;
+
+FROM orders
+WHERE
+  status = 'active'
+;
+
+FROM products
+ORDER BY
+   name
+;

--- a/tests/fixtures/select/from_first.input.sql
+++ b/tests/fixtures/select/from_first.input.sql
@@ -1,0 +1,3 @@
+SELECT * FROM people;
+SELECT * FROM orders WHERE status = 'active';
+SELECT * FROM products ORDER BY name;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -78,3 +78,38 @@ def test_pivot_order_by_formats_without_warning():
     # Idempotent
     result2, _ = format_sql(result)
     assert result == result2
+
+
+class TestFromFirst:
+    def test_select_star_becomes_from_first(self):
+        from jarify.formatter import format_sql
+        out, _ = format_sql("SELECT * FROM people")
+        assert out.startswith("FROM people")
+        assert "SELECT" not in out
+
+    def test_select_star_with_where(self):
+        from jarify.formatter import format_sql
+        out, _ = format_sql("SELECT * FROM people WHERE age > 18")
+        assert "FROM people" in out
+        assert "SELECT" not in out
+
+    def test_select_star_with_join_keeps_select(self):
+        from jarify.formatter import format_sql
+        out, _ = format_sql("SELECT * FROM people LEFT JOIN orders ON people.id = orders.person_id")
+        assert "SELECT" in out
+
+    def test_select_distinct_star_keeps_select(self):
+        from jarify.formatter import format_sql
+        out, _ = format_sql("SELECT DISTINCT * FROM people")
+        assert "SELECT DISTINCT" in out
+
+    def test_explicit_columns_unaffected(self):
+        from jarify.formatter import format_sql
+        out, _ = format_sql("SELECT id, name FROM people")
+        assert "SELECT" in out
+
+    def test_prefer_from_first_false_keeps_select(self):
+        from jarify.config import JarifyConfig
+        from jarify.formatter import format_sql
+        out, _ = format_sql("SELECT * FROM people", JarifyConfig(prefer_from_first=False))
+        assert "SELECT" in out


### PR DESCRIPTION
Implements the FROM-first formatting rule.

## What

`SELECT * FROM t` → `FROM t` (and `WHERE`, `ORDER BY`, etc. are preserved)

## How

- Added `prefer_from_first: bool = True` to `JarifyConfig`
- Overrides `select_sql` in `JarifyGenerator`: when the only expression is `*` and there are no JOINs, strips the `SELECT` line
- JOINs excluded: sqlglot re-parses `FROM func() JOIN` by attaching the join to the table node rather than the Select, causing an idempotency shift — keeping `SELECT *` for joined queries avoids this

## Tests

- `tests/fixtures/select/from_first` — simple, WHERE, ORDER BY cases
- `TestFromFirst` — star converts, JOIN keeps SELECT, DISTINCT keeps SELECT, explicit columns unaffected, opt-out via config

Resolves #20