### PR TITLE
feat(rules): add 6 new formatting and lint rules

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -138,6 +138,42 @@ WHERE
 
 ---
 
+### `GROUP BY` — one expression per line
+
+Every `GROUP BY` expression is on its own line using the same leading-comma style as `SELECT`. `GROUP BY ALL` is exempt and stays on one line.
+
+**Bad**
+```sql
+SELECT a, b, count(*) FROM t GROUP BY a, b
+```
+
+**Good**
+```sql
+SELECT
+   a
+  ,b
+  ,count(*)
+FROM t
+GROUP BY
+   a
+  ,b
+;
+```
+
+`GROUP BY ALL` (DuckDB shorthand) stays inline:
+
+```sql
+SELECT
+   a
+  ,b
+  ,count(*)
+FROM t
+GROUP BY ALL
+;
+```
+
+---
+
 ### CTE layout
 
 The opening parenthesis goes on its own line. Each subsequent CTE is prefixed with a comma (no space between comma and name).
@@ -250,6 +286,27 @@ SELECT
    a
 FROM foo
 INNER JOIN bar
+  ON foo.id = bar.id
+;
+```
+
+---
+
+### `LEFT OUTER JOIN` → `LEFT JOIN`
+
+The redundant `OUTER` keyword is dropped from `LEFT` and `RIGHT` joins. `FULL OUTER JOIN` is preserved.
+
+**Bad**
+```sql
+SELECT a FROM foo LEFT OUTER JOIN bar ON foo.id = bar.id
+```
+
+**Good**
+```sql
+SELECT
+   a
+FROM foo
+LEFT JOIN bar
   ON foo.id = bar.id
 ;
 ```
@@ -487,5 +544,94 @@ SELECT
 FROM t
 QUALIFY
   rn = 1
+;
+```
+
+---
+
+### `prefer-group-by-all`
+
+Flag explicit `GROUP BY col1, col2, ...` when all non-aggregated `SELECT` columns are listed. Use `GROUP BY ALL` instead.
+
+**Bad**
+```sql
+SELECT a, b, count(*) AS n FROM t GROUP BY a, b
+```
+
+**Good**
+```sql
+SELECT
+   a
+  ,b
+  ,count(*) AS n
+FROM t
+GROUP BY ALL
+;
+```
+
+---
+
+### `prefer-using-over-on`
+
+Flag `ON a.col = b.col` equi-joins where both sides reference the same column name. Use `USING (col)` instead.
+
+**Bad**
+```sql
+SELECT a.x FROM a INNER JOIN b ON a.id = b.id
+```
+
+**Good**
+```sql
+SELECT
+   a.x
+FROM a
+INNER JOIN b
+  USING (id)
+;
+```
+
+---
+
+### `consistent-empty-array`
+
+Flag `'[]'::type[]` (string-cast empty arrays) in favour of the native DuckDB `[]` empty array literal.
+
+**Bad**
+```sql
+SELECT COALESCE(tags, '[]')::text[] AS tags FROM t
+```
+
+**Good**
+```sql
+SELECT
+   COALESCE(tags, [])::TEXT[] AS tags
+FROM t
+;
+```
+
+---
+
+### `no-select-star-in-cte`
+
+Flag `SELECT *` inside CTE body definitions. Stricter variant of `no-select-star` that applies only within CTE bodies.
+
+**Bad**
+```sql
+WITH _base AS (SELECT * FROM source_table)
+SELECT id FROM _base
+```
+
+**Good**
+```sql
+WITH _base AS
+(
+  SELECT
+     id
+    ,name
+  FROM source_table
+)
+SELECT
+   id
+FROM _base
 ;
 ```

--- a/src/jarify/config.py
+++ b/src/jarify/config.py
@@ -41,6 +41,10 @@ class JarifyConfig:
     duckdb_type_style: str = "warn"  # prefer canonical DuckDB type names
     duckdb_prefer_qualify: str = "warn"  # prefer QUALIFY over subquery window filter
     cte_naming: str = "warn"  # CTE names must start with an underscore
+    prefer_group_by_all: str = "warn"  # suggest GROUP BY ALL when listing all non-agg cols
+    prefer_using_over_on: str = "warn"  # suggest USING (col) over ON a.col = b.col
+    consistent_empty_array: str = "warn"  # prefer [] over '[]'::type[] empty array
+    no_select_star_in_cte: str = "warn"  # flag SELECT * inside CTE bodies
 
     # --- per-rule overrides (populated from [rules.*] in toml) ---
     rules: dict[str, Any] = field(default_factory=dict)

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -168,7 +168,7 @@ class JarifyGenerator(DuckDB.Generator):
         return "\n".join(parts)
 
     # ------------------------------------------------------------------
-    # JOIN normalization: bare JOIN → INNER JOIN
+    # JOIN normalization: bare JOIN → INNER JOIN; LEFT/RIGHT OUTER → LEFT/RIGHT
     # ------------------------------------------------------------------
 
     def join_sql(self, expression: exp.Join) -> str:
@@ -176,6 +176,10 @@ class JarifyGenerator(DuckDB.Generator):
             # Bare JOIN with no qualifier — normalize to INNER JOIN
             expression = expression.copy()
             expression.set("kind", "INNER")
+        elif expression.side in ("LEFT", "RIGHT") and expression.kind == "OUTER":
+            # DROP redundant OUTER: LEFT OUTER JOIN → LEFT JOIN
+            expression = expression.copy()
+            expression.set("kind", None)
         return super().join_sql(expression)
 
     # ------------------------------------------------------------------
@@ -255,6 +259,21 @@ class JarifyGenerator(DuckDB.Generator):
             # Uses multiline ^ so indented "  SELECT" inside CTEs is never matched.
             return re.sub(r"(?m)^SELECT\n", "", sql)
         return super().select_sql(expression)
+
+    # ------------------------------------------------------------------
+    # GROUP BY: one expression per line in pretty mode
+    # ------------------------------------------------------------------
+
+    def group_sql(self, expression: exp.Group) -> str:
+        group_by_all = expression.args.get("all")
+        if group_by_all is True:
+            return self.seg("GROUP BY ALL")
+        if self.pretty and expression.expressions:
+            # Force multi-line: mirror op_expressions but always flat=False
+            modifier = " DISTINCT" if group_by_all is False else ""
+            expressions_sql = self.expressions(expression, flat=False)
+            return f"{self.seg(f'GROUP BY{modifier}')}{self.sep() if expressions_sql else ''}{expressions_sql}"
+        return super().group_sql(expression)
 
     # ------------------------------------------------------------------
     # Cast: prefer :: shorthand over CAST()

--- a/src/jarify/rules/__init__.py
+++ b/src/jarify/rules/__init__.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from jarify.rules.base import FormatterRule
+from jarify.rules.consistent_empty_array import ConsistentEmptyArrayRule
 from jarify.rules.cte_naming import CteNamingRule
 from jarify.rules.duckdb_prefer_qualify import DuckdbPreferQualifyRule
 from jarify.rules.duckdb_type_style import DuckdbTypeStyleRule
 from jarify.rules.keyword_case import KeywordCaseRule
 from jarify.rules.no_implicit_cross_join import NoImplicitCrossJoinRule
 from jarify.rules.no_select_star import NoSelectStarRule
+from jarify.rules.no_select_star_in_cte import NoSelectStarInCteRule
 from jarify.rules.no_unused_cte import NoUnusedCteRule
+from jarify.rules.prefer_group_by_all import PreferGroupByAllRule
+from jarify.rules.prefer_using_over_on import PreferUsingOverOnRule
 from jarify.rules.trailing_commas import TrailingCommasRule
 
 if TYPE_CHECKING:
@@ -46,5 +50,13 @@ def get_default_rules(config: JarifyConfig) -> list[FormatterRule]:
         rules.append(DuckdbPreferQualifyRule(severity=config.duckdb_prefer_qualify))
     if config.cte_naming != "off":
         rules.append(CteNamingRule(severity=config.cte_naming))
+    if config.prefer_group_by_all != "off":
+        rules.append(PreferGroupByAllRule(severity=config.prefer_group_by_all))
+    if config.prefer_using_over_on != "off":
+        rules.append(PreferUsingOverOnRule(severity=config.prefer_using_over_on))
+    if config.consistent_empty_array != "off":
+        rules.append(ConsistentEmptyArrayRule(severity=config.consistent_empty_array))
+    if config.no_select_star_in_cte != "off":
+        rules.append(NoSelectStarInCteRule(severity=config.no_select_star_in_cte))
 
     return rules

--- a/src/jarify/rules/consistent_empty_array.py
+++ b/src/jarify/rules/consistent_empty_array.py
@@ -1,0 +1,65 @@
+"""Rule: flag '[]'::type[] string-cast empty arrays; prefer [] literal."""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+from sqlglot.expressions import DataType
+
+from jarify.rules.base import FormatterRule
+from jarify.types import LintViolation
+
+
+class ConsistentEmptyArrayRule(FormatterRule):
+    """Lint: flag '[]'::type[] (string-cast) in favour of native [] empty array literal."""
+
+    def __init__(self, severity: str = "warn") -> None:
+        self.severity = severity
+
+    @property
+    def name(self) -> str:
+        return "consistent-empty-array"
+
+    def apply(self, tree: exp.Expression) -> exp.Expression:
+        return tree
+
+    def check(self, tree: exp.Expression) -> list[LintViolation]:
+        if self.severity == "off":
+            return []
+        violations: list[LintViolation] = []
+
+        for cast in tree.find_all(exp.Cast):
+            if not (isinstance(cast.to, exp.DataType) and cast.to.this == DataType.Type.ARRAY):
+                continue
+
+            canonical = cast.to.sql(dialect="duckdb")
+
+            # Pattern 1: '[]'::type[] — literal directly cast to array
+            if isinstance(cast.this, exp.Literal) and cast.this.is_string and cast.this.name == "[]":
+                violations.append(
+                    LintViolation(
+                        rule=self.name,
+                        severity=self.severity,
+                        message=(
+                            f"Use the native empty array literal [] instead of '[]'::{canonical};"
+                            " cast the COALESCE result to the target type when needed"
+                        ),
+                    )
+                )
+
+            # Pattern 2: COALESCE(x, '[]')::type[] — '[]' string fallback inside COALESCE
+            elif isinstance(cast.this, exp.Coalesce):
+                for arg in cast.this.expressions:
+                    if isinstance(arg, exp.Literal) and arg.is_string and arg.name == "[]":
+                        violations.append(
+                            LintViolation(
+                                rule=self.name,
+                                severity=self.severity,
+                                message=(
+                                    f"Use [] instead of '[]' as the COALESCE fallback in COALESCE(...)::{ canonical};"
+                                    " prefer native empty array literal"
+                                ),
+                            )
+                        )
+                        break
+
+        return violations

--- a/src/jarify/rules/no_select_star_in_cte.py
+++ b/src/jarify/rules/no_select_star_in_cte.py
@@ -1,0 +1,48 @@
+"""Rule: flag SELECT * inside CTE body definitions."""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+
+from jarify.rules.base import FormatterRule
+from jarify.types import LintViolation
+
+
+class NoSelectStarInCteRule(FormatterRule):
+    """Lint: flag SELECT * used inside a CTE body (stricter than no-select-star)."""
+
+    def __init__(self, severity: str = "warn") -> None:
+        self.severity = severity
+
+    @property
+    def name(self) -> str:
+        return "no-select-star-in-cte"
+
+    def apply(self, tree: exp.Expression) -> exp.Expression:
+        return tree
+
+    def check(self, tree: exp.Expression) -> list[LintViolation]:
+        if self.severity == "off":
+            return []
+        violations: list[LintViolation] = []
+
+        with_clause = tree.args.get("with_")
+        if not with_clause:
+            return []
+
+        for cte in with_clause.expressions:
+            cte_name = cte.alias or "<unnamed>"
+            for star in cte.this.find_all(exp.Star):
+                parent = star.parent
+                if isinstance(parent, exp.Select) or (
+                    isinstance(parent, exp.Column) and isinstance(parent.parent, exp.Select)
+                ):
+                    violations.append(
+                        LintViolation(
+                            rule=self.name,
+                            severity=self.severity,
+                            message=f"Avoid SELECT * inside CTE '{cte_name}'; list columns explicitly",
+                        )
+                    )
+
+        return violations

--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -1,0 +1,59 @@
+"""Rule: suggest GROUP BY ALL when all non-aggregated SELECT columns are listed."""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+
+from jarify.rules.base import FormatterRule
+from jarify.types import LintViolation
+
+
+class PreferGroupByAllRule(FormatterRule):
+    """Lint: flag explicit GROUP BY col list when GROUP BY ALL would be equivalent."""
+
+    def __init__(self, severity: str = "warn") -> None:
+        self.severity = severity
+
+    @property
+    def name(self) -> str:
+        return "prefer-group-by-all"
+
+    def apply(self, tree: exp.Expression) -> exp.Expression:
+        return tree
+
+    def check(self, tree: exp.Expression) -> list[LintViolation]:
+        if self.severity == "off":
+            return []
+        violations: list[LintViolation] = []
+
+        for select in tree.find_all(exp.Select):
+            group = select.args.get("group")
+            if not group or not group.expressions:
+                continue
+            if group.args.get("all"):
+                # Already GROUP BY ALL — nothing to flag
+                continue
+
+            # Collect non-aggregate SELECT expressions (unwrap aliases)
+            non_agg_sqls: list[str] = []
+            for item in select.expressions:
+                inner = item.this if isinstance(item, exp.Alias) else item
+                if not inner.find(exp.AggFunc):
+                    non_agg_sqls.append(inner.sql(dialect="duckdb"))
+
+            if not non_agg_sqls:
+                continue
+
+            group_sqls = {e.sql(dialect="duckdb") for e in group.expressions}
+            non_agg_set = set(non_agg_sqls)
+
+            if non_agg_set and non_agg_set == group_sqls:
+                violations.append(
+                    LintViolation(
+                        rule=self.name,
+                        severity=self.severity,
+                        message="All non-aggregated SELECT columns are listed in GROUP BY; prefer GROUP BY ALL",
+                    )
+                )
+
+        return violations

--- a/src/jarify/rules/prefer_using_over_on.py
+++ b/src/jarify/rules/prefer_using_over_on.py
@@ -1,0 +1,70 @@
+"""Rule: suggest USING (col) over ON a.col = b.col for equi-joins."""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+
+from jarify.rules.base import FormatterRule
+from jarify.types import LintViolation
+
+
+class PreferUsingOverOnRule(FormatterRule):
+    """Lint: flag ON a.col = b.col equi-joins where both sides share the same column name."""
+
+    def __init__(self, severity: str = "warn") -> None:
+        self.severity = severity
+
+    @property
+    def name(self) -> str:
+        return "prefer-using-over-on"
+
+    def apply(self, tree: exp.Expression) -> exp.Expression:
+        return tree
+
+    def check(self, tree: exp.Expression) -> list[LintViolation]:
+        if self.severity == "off":
+            return []
+        violations: list[LintViolation] = []
+
+        for join in tree.find_all(exp.Join):
+            if join.args.get("using"):
+                continue
+            on = join.args.get("on")
+            if not on:
+                continue
+            # Collect all equality conditions at the top level of the ON clause
+            conditions = _flatten_and(on)
+            rewritable = []
+            for cond in conditions:
+                if not isinstance(cond, exp.EQ):
+                    continue
+                left, right = cond.left, cond.right
+                if (
+                    isinstance(left, exp.Column)
+                    and isinstance(right, exp.Column)
+                    and left.name
+                    and left.name == right.name
+                ):
+                    rewritable.append(left.name)
+
+            if rewritable:
+                cols = ", ".join(rewritable)
+                violations.append(
+                    LintViolation(
+                        rule=self.name,
+                        severity=self.severity,
+                        message=(
+                            f"ON clause can be simplified to USING ({cols})"
+                            " — both sides reference the same column name"
+                        ),
+                    )
+                )
+
+        return violations
+
+
+def _flatten_and(node: exp.Expression) -> list[exp.Expression]:
+    """Flatten a nested AND chain into a flat list of individual conditions."""
+    if isinstance(node, exp.And):
+        return _flatten_and(node.left) + _flatten_and(node.right)
+    return [node]

--- a/tests/fixtures/complex/real_world.expected.sql
+++ b/tests/fixtures/complex/real_world.expected.sql
@@ -80,7 +80,7 @@ LEFT JOIN _enrollments AS e
   ON e.participant_key = all_e.participant_key
   AND e.program_supplier_key = rs.program_supplier_key
   AND e.enabled = TRUE
-LEFT OUTER JOIN _prices AS p
+LEFT JOIN _prices AS p
   ON sc.version = p.version
   AND sc.sku_key = p.sku_key
   AND p.end_date IS NULL

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -113,3 +113,44 @@ class TestFromFirst:
         from jarify.formatter import format_sql
         out, _ = format_sql("SELECT * FROM people", JarifyConfig(prefer_from_first=False))
         assert "SELECT" in out
+
+
+class TestLeftOuterJoinNormalization:
+    def test_left_outer_join_normalized(self):
+        out, _ = format_sql("SELECT a FROM foo LEFT OUTER JOIN bar ON foo.id = bar.id")
+        assert "LEFT JOIN" in out
+        assert "LEFT OUTER JOIN" not in out
+
+    def test_right_outer_join_normalized(self):
+        out, _ = format_sql("SELECT a FROM foo RIGHT OUTER JOIN bar ON foo.id = bar.id")
+        assert "RIGHT JOIN" in out
+        assert "RIGHT OUTER JOIN" not in out
+
+    def test_left_join_unchanged(self):
+        out, _ = format_sql("SELECT a FROM foo LEFT JOIN bar ON foo.id = bar.id")
+        assert "LEFT JOIN" in out
+
+    def test_full_outer_join_preserved(self):
+        out, _ = format_sql("SELECT a FROM foo FULL OUTER JOIN bar ON foo.id = bar.id")
+        assert "FULL" in out
+
+
+class TestGroupByPerLine:
+    def test_group_by_multi_column_one_per_line(self):
+        out, _ = format_sql("SELECT a, b, count(*) FROM t GROUP BY a, b")
+        lines = out.splitlines()
+        group_by_idx = next(i for i, line in enumerate(lines) if "GROUP BY" in line)
+        # The line with GROUP BY should not contain column names on the same line
+        group_by_line = lines[group_by_idx]
+        assert group_by_line.strip() == "GROUP BY", (
+            f"Expected 'GROUP BY' on its own line, got: {group_by_line!r}"
+        )
+
+    def test_group_by_all_stays_inline(self):
+        out, _ = format_sql("SELECT a, b, count(*) FROM t GROUP BY ALL")
+        assert "GROUP BY ALL" in out
+
+    def test_group_by_single_column(self):
+        out, _ = format_sql("SELECT a, count(*) FROM t GROUP BY a")
+        assert "GROUP BY" in out
+        assert "a" in out

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -116,3 +116,93 @@ class TestCteNaming:
         assert "WITH _base" in out
         assert "FROM _base" in out
 
+
+class TestPreferGroupByAll:
+    def test_warns_when_all_non_agg_cols_listed(self):
+        sql = "SELECT a, b, count(*) AS n FROM t GROUP BY a, b"
+        rules = _lint(sql)
+        assert "prefer-group-by-all" in rules
+
+    def test_no_warn_for_group_by_all(self):
+        sql = "SELECT a, b, count(*) AS n FROM t GROUP BY ALL"
+        rules = _lint(sql)
+        assert "prefer-group-by-all" not in rules
+
+    def test_no_warn_when_group_by_is_subset(self):
+        # Only grouping by one of two non-agg columns — not equivalent to GROUP BY ALL
+        sql = "SELECT a, b, count(*) AS n FROM t GROUP BY a"
+        rules = _lint(sql)
+        assert "prefer-group-by-all" not in rules
+
+    def test_off_disables_rule(self):
+        sql = "SELECT a, b, count(*) AS n FROM t GROUP BY a, b"
+        rules = _lint(sql, prefer_group_by_all="off")
+        assert "prefer-group-by-all" not in rules
+
+
+class TestPreferUsingOverOn:
+    def test_warns_on_same_column_name_equijoin(self):
+        sql = "SELECT a.x FROM a INNER JOIN b ON a.id = b.id"
+        rules = _lint(sql)
+        assert "prefer-using-over-on" in rules
+
+    def test_no_warn_when_using_already_used(self):
+        sql = "SELECT a.x FROM a INNER JOIN b USING (id)"
+        rules = _lint(sql)
+        assert "prefer-using-over-on" not in rules
+
+    def test_no_warn_when_columns_differ(self):
+        sql = "SELECT a.x FROM a INNER JOIN b ON a.foo = b.bar"
+        rules = _lint(sql)
+        assert "prefer-using-over-on" not in rules
+
+    def test_off_disables_rule(self):
+        sql = "SELECT a.x FROM a INNER JOIN b ON a.id = b.id"
+        rules = _lint(sql, prefer_using_over_on="off")
+        assert "prefer-using-over-on" not in rules
+
+
+class TestConsistentEmptyArray:
+    def test_warns_on_string_cast_empty_array(self):
+        sql = "SELECT COALESCE(tags, '[]')::text[] AS tags FROM t"
+        rules = _lint(sql)
+        assert "consistent-empty-array" in rules
+
+    def test_no_warn_on_native_empty_array(self):
+        sql = "SELECT COALESCE(tags, []) AS tags FROM t"
+        rules = _lint(sql)
+        assert "consistent-empty-array" not in rules
+
+    def test_off_disables_rule(self):
+        sql = "SELECT COALESCE(tags, '[]')::text[] AS tags FROM t"
+        rules = _lint(sql, consistent_empty_array="off")
+        assert "consistent-empty-array" not in rules
+
+
+class TestNoSelectStarInCte:
+    def test_warns_on_select_star_in_cte(self):
+        sql = "WITH _base AS (SELECT * FROM t) SELECT a FROM _base"
+        rules = _lint(sql)
+        assert "no-select-star-in-cte" in rules
+
+    def test_no_warn_when_cte_lists_columns(self):
+        sql = "WITH _base AS (SELECT a, b FROM t) SELECT a FROM _base"
+        rules = _lint(sql)
+        assert "no-select-star-in-cte" not in rules
+
+    def test_no_warn_on_star_outside_cte(self):
+        # SELECT * in the outer query is caught by no-select-star, not this rule
+        sql = "WITH _base AS (SELECT a FROM t) SELECT * FROM _base"
+        rules = _lint(sql, no_select_star="off")
+        assert "no-select-star-in-cte" not in rules
+
+    def test_off_disables_rule(self):
+        sql = "WITH _base AS (SELECT * FROM t) SELECT a FROM _base"
+        rules = _lint(sql, no_select_star_in_cte="off")
+        assert "no-select-star-in-cte" not in rules
+
+    def test_no_warn_count_star_in_cte(self):
+        sql = "WITH _base AS (SELECT COUNT(*) AS n FROM t) SELECT n FROM _base"
+        rules = _lint(sql)
+        assert "no-select-star-in-cte" not in rules
+


### PR DESCRIPTION
## Summary

Implements 6 of the 8 rules identified in issue #22 from a review of a real-world DuckDB query.

## Formatting rules

### `LEFT OUTER JOIN` → `LEFT JOIN`
Drops the redundant `OUTER` keyword from `LEFT` and `RIGHT` joins, mirroring the existing bare `JOIN` → `INNER JOIN` normalization. `FULL OUTER JOIN` is preserved.

### `GROUP BY` — one expression per line
Each `GROUP BY` expression now appears on its own line using the leading-comma style, parallel to the existing `AND`/`OR` rule. `GROUP BY ALL` stays inline.

## Lint rules (default: `warn`, configurable via `jarify.toml`)

| Rule | Description |
|------|-------------|
| `prefer-group-by-all` | Flag explicit `GROUP BY col1, col2` when all non-aggregated SELECT columns are listed; suggest `GROUP BY ALL` |
| `prefer-using-over-on` | Flag `ON a.col = b.col` equi-joins where both sides share a column name; suggest `USING (col)` |
| `consistent-empty-array` | Flag `'[]'::type[]` string-cast empty arrays; prefer native `[]` literal (handles both direct cast and COALESCE fallback patterns) |
| `no-select-star-in-cte` | Flag `SELECT *` inside CTE body definitions (stricter sibling of `no-select-star`) |

## Other changes
- All rules wired into `JarifyConfig` with severity defaults
- Style guide updated with bad/good examples for every new rule
- `real_world` fixture snapshot updated to reflect `LEFT OUTER JOIN` normalization
- 23 new tests (82 total, all passing)

## Deferred
Rules for multi-line struct constructor alignment and `DISTINCT`-inside-aggregates formatting require deeper sqlglot AST investigation and are tracked in a follow-up issue.

Closes #22