### PR TITLE
feat(generator): format CREATE TABLE with aligned columns and own-line paren

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -475,6 +475,35 @@ FROM u
 
 ---
 
+### `CREATE TABLE` layout
+
+The opening parenthesis goes on its own line. Column names are padded to align all type tokens, and types are padded to align all constraint tokens when any column carries constraints. A blank line separates column definitions from table-level constraints (`PRIMARY KEY`, `UNIQUE`, `CHECK`, etc.).
+
+**Bad**
+```sql
+CREATE OR REPLACE TABLE examples (
+   transaction_id TEXT NOT NULL,
+   program_supplier_key TEXT NOT NULL,
+   seller_key TEXT,
+   PRIMARY KEY (program_supplier_key, transaction_id)
+)
+```
+
+**Good**
+```sql
+CREATE OR REPLACE TABLE examples
+(
+   transaction_id       TEXT NOT NULL
+  ,program_supplier_key TEXT NOT NULL
+  ,seller_key           TEXT
+
+  ,PRIMARY KEY (program_supplier_key, transaction_id)
+)
+;
+```
+
+---
+
 ## Lint Rules
 
 Lint rules report violations but do not modify the SQL. All rules default to `warn`. Severity can be set to `off`, `warn`, or `error` in `jarify.toml`.

--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -6,9 +6,9 @@ Jarify enforces a single, non-configurable SQL style. This document describes ev
 
 ## Formatting Rules
 
-### Keywords — uppercase
+### Keywords — uppercase; data types — lowercase
 
-SQL keywords are always uppercase.
+SQL keywords (`SELECT`, `FROM`, `WHERE`, `JOIN`, `NOT NULL`, etc.) are always uppercase. Data type names (`text`, `int`, `timestamp`, `decimal`, etc.) are always lowercase.
 
 **Bad**
 ```sql
@@ -23,6 +23,30 @@ SELECT
 FROM my_table
 WHERE
   x > 1
+;
+```
+
+Type names are lowercased even in casts and `CREATE TABLE`:
+
+**Bad**
+```sql
+SELECT a::TEXT, b::INTEGER FROM t
+CREATE TABLE t (id INTEGER NOT NULL, name TEXT)
+```
+
+**Good**
+```sql
+SELECT
+   a::text
+  ,b::int
+FROM t
+;
+
+CREATE TABLE t
+(
+   id   int  NOT NULL
+  ,name text
+)
 ;
 ```
 
@@ -584,8 +608,8 @@ Flag non-canonical DuckDB type names. Use the canonical form instead.
 
 | Non-canonical | Canonical |
 |---------------|-----------|
-| `FLOAT`, `FLOAT4` | `REAL` |
-| `NVARCHAR` | `TEXT` |
+| `float`, `float4` | `real` |
+| `nvarchar` | `text` |
 
 **Bad**
 ```sql
@@ -594,7 +618,7 @@ CREATE TABLE t (score FLOAT, label NVARCHAR)
 
 **Good**
 ```sql
-CREATE TABLE t (score REAL, label TEXT)
+CREATE TABLE t (score real, label text)
 ```
 
 ---

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -327,6 +327,13 @@ class JarifyGenerator(DuckDB.Generator):
         return sep.join(arg_sqls)
 
     # ------------------------------------------------------------------
+    # Data types — always lowercase (text, int, timestamp, …)
+    # ------------------------------------------------------------------
+
+    def datatype_sql(self, expression: exp.DataType) -> str:
+        return super().datatype_sql(expression).lower()
+
+    # ------------------------------------------------------------------
     # CREATE TABLE: opening paren on its own line, column alignment,
     # blank line before table-level constraints
     # ------------------------------------------------------------------

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -12,6 +12,8 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - SELECT * FROM t → FROM t (DuckDB FROM-first syntax)
 - Struct tuple casts (val, ...)::type use leading-comma style when multi-line
 - DISTINCT inside aggregates appears on its own line when the call wraps
+- CREATE TABLE: opening paren on its own line, column name/type alignment,
+  blank line before table-level constraints
 """
 
 from __future__ import annotations
@@ -48,6 +50,8 @@ class JarifyGenerator(DuckDB.Generator):
         )
         self._config = config
         self._as_align_width: int | None = None  # set during SELECT expression rendering
+        self._col_name_align: int | None = None  # set during CREATE TABLE column rendering
+        self._col_type_align: int | None = None  # set during CREATE TABLE column rendering
 
     # ------------------------------------------------------------------
     # Leading-comma style: ,col  (comma at pad, content at pad+1)
@@ -321,3 +325,81 @@ class JarifyGenerator(DuckDB.Generator):
                 return self.indent("\n" + "\n".join(parts) + "\n", skip_first=True, skip_last=True)
             return self.indent("\n" + f"{sep.strip()}\n".join(arg_sqls) + "\n", skip_first=True, skip_last=True)
         return sep.join(arg_sqls)
+
+    # ------------------------------------------------------------------
+    # CREATE TABLE: opening paren on its own line, column alignment,
+    # blank line before table-level constraints
+    # ------------------------------------------------------------------
+
+    def schema_sql(self, expression: exp.Schema) -> str:
+        this = self.sql(expression, "this")
+        sql = self.schema_columns_sql(expression)
+        if this and sql and self.pretty:
+            return f"{this}\n{sql}"
+        return f"{this} {sql}" if this and sql else this or sql
+
+    def schema_columns_sql(self, expression: exp.Expr) -> str:  # type: ignore[override]
+        if not expression.expressions:
+            return ""
+        if not self.pretty:
+            return super().schema_columns_sql(expression)
+
+        col_defs = [e for e in expression.expressions if isinstance(e, exp.ColumnDef)]
+        table_constraints = [e for e in expression.expressions if not isinstance(e, exp.ColumnDef)]
+
+        # Compute alignment widths across all column definitions
+        col_name_width = max((len(self.sql(c, "this")) for c in col_defs), default=0)
+        type_width = max(
+            (len(self.sql(c, "kind")) for c in col_defs if self.sql(c, "kind")),
+            default=0,
+        )
+
+        saved_name = self._col_name_align
+        saved_type = self._col_type_align
+        self._col_name_align = col_name_width
+        self._col_type_align = type_width
+        try:
+            col_sqls = [self.columndef_sql(c) for c in col_defs]
+            constraint_sqls = [self.sql(c) for c in table_constraints]
+        finally:
+            self._col_name_align = saved_name
+            self._col_type_align = saved_type
+
+        # Build body with leading-comma style
+        lines: list[str] = []
+        for i, sql in enumerate(col_sqls):
+            leader = " " if i == 0 else ","
+            lines.append(f"{leader}{sql}")
+
+        if constraint_sqls:
+            lines.append("")  # blank line separating columns from table constraints
+            for sql in constraint_sqls:
+                lines.append(f",{sql}")
+
+        # Indent each non-blank line by pad spaces; keep blank lines clean
+        indented = [(" " * self.pad + line) if line else "" for line in lines]
+        body = "\n".join(indented)
+        return f"(\n{body}\n)"
+
+    def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
+        column = self.sql(expression, "this")
+        kind = self.sql(expression, "kind")
+        constraints_sql = self.expressions(expression, key="constraints", sep=" ", flat=True)
+        exists = "IF NOT EXISTS " if expression.args.get("exists") else ""
+        position = self.sql(expression, "position")
+
+        if expression.find(exp.ComputedColumnConstraint) and not self.COMPUTED_COLUMN_WITH_TYPE:
+            kind = ""
+
+        # Apply column name padding when inside a CREATE TABLE schema body
+        col_part = column.ljust(self._col_name_align) if self._col_name_align else column
+
+        # Pad type to align constraints column, but only when this column has constraints
+        if self._col_type_align and kind and constraints_sql:
+            kind_part = f"{sep}{kind.ljust(self._col_type_align)}"
+        else:
+            kind_part = f"{sep}{kind}" if kind else ""
+
+        constraints_part = f" {constraints_sql}" if constraints_sql else ""
+        position_part = f" {position}" if position else ""
+        return f"{exists}{col_part}{kind_part}{constraints_part}{position_part}"

--- a/tests/fixtures/create_table/basic.expected.sql
+++ b/tests/fixtures/create_table/basic.expected.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE TABLE examples
+(
+   transaction_id       TEXT                    NOT NULL
+  ,request_id           TEXT                    NOT NULL
+  ,participant_key      TEXT                    NOT NULL
+  ,time_frame           TEXT                    NOT NULL
+  ,program_supplier_key TEXT                    NOT NULL
+  ,properties           key_value_pair_struct[] NOT NULL DEFAULT []
+  ,transaction_type     TEXT                    NOT NULL
+  ,sku_key              TEXT                    NOT NULL
+  ,uom_key              TEXT                    NOT NULL
+  ,quantity             TEXT                    NOT NULL
+  ,amount               TEXT                    NOT NULL
+  ,invoice_date         TEXT                    NOT NULL
+  ,seller_key           TEXT
+  ,purchaser            purchaser_struct
+
+  ,PRIMARY KEY (program_supplier_key, time_frame, request_id, transaction_id)
+)
+;

--- a/tests/fixtures/create_table/basic.expected.sql
+++ b/tests/fixtures/create_table/basic.expected.sql
@@ -1,18 +1,18 @@
 CREATE OR REPLACE TABLE examples
 (
-   transaction_id       TEXT                    NOT NULL
-  ,request_id           TEXT                    NOT NULL
-  ,participant_key      TEXT                    NOT NULL
-  ,time_frame           TEXT                    NOT NULL
-  ,program_supplier_key TEXT                    NOT NULL
+   transaction_id       text                    NOT NULL
+  ,request_id           text                    NOT NULL
+  ,participant_key      text                    NOT NULL
+  ,time_frame           text                    NOT NULL
+  ,program_supplier_key text                    NOT NULL
   ,properties           key_value_pair_struct[] NOT NULL DEFAULT []
-  ,transaction_type     TEXT                    NOT NULL
-  ,sku_key              TEXT                    NOT NULL
-  ,uom_key              TEXT                    NOT NULL
-  ,quantity             TEXT                    NOT NULL
-  ,amount               TEXT                    NOT NULL
-  ,invoice_date         TEXT                    NOT NULL
-  ,seller_key           TEXT
+  ,transaction_type     text                    NOT NULL
+  ,sku_key              text                    NOT NULL
+  ,uom_key              text                    NOT NULL
+  ,quantity             text                    NOT NULL
+  ,amount               text                    NOT NULL
+  ,invoice_date         text                    NOT NULL
+  ,seller_key           text
   ,purchaser            purchaser_struct
 
   ,PRIMARY KEY (program_supplier_key, time_frame, request_id, transaction_id)

--- a/tests/fixtures/create_table/basic.input.sql
+++ b/tests/fixtures/create_table/basic.input.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE TABLE examples
+(
+   transaction_id       text                    NOT NULL
+  ,request_id           text                    NOT NULL
+  ,participant_key      text                    NOT NULL
+  ,time_frame           text                    NOT NULL
+  ,program_supplier_key text                    NOT NULL
+  ,properties           key_value_pair_struct[] NOT NULL DEFAULT []
+  ,transaction_type     text                    NOT NULL
+  ,sku_key              text                    NOT NULL
+  ,uom_key              text                    NOT NULL
+  ,quantity             text                    NOT NULL
+  ,amount               text                    NOT NULL
+  ,invoice_date         text                    NOT NULL
+  ,seller_key           text
+  ,purchaser            purchaser_struct
+
+  ,PRIMARY KEY (program_supplier_key, time_frame, request_id, transaction_id)
+)
+;

--- a/tests/fixtures/create_table/inline_primary_key.expected.sql
+++ b/tests/fixtures/create_table/inline_primary_key.expected.sql
@@ -1,7 +1,7 @@
 CREATE TABLE orders
 (
-   order_id INT            NOT NULL PRIMARY KEY
-  ,customer TEXT           NOT NULL
-  ,total    DECIMAL(18, 3)
+   order_id int            NOT NULL PRIMARY KEY
+  ,customer text           NOT NULL
+  ,total    decimal(18, 3)
 )
 ;

--- a/tests/fixtures/create_table/inline_primary_key.expected.sql
+++ b/tests/fixtures/create_table/inline_primary_key.expected.sql
@@ -1,0 +1,7 @@
+CREATE TABLE orders
+(
+   order_id INT            NOT NULL PRIMARY KEY
+  ,customer TEXT           NOT NULL
+  ,total    DECIMAL(18, 3)
+)
+;

--- a/tests/fixtures/create_table/inline_primary_key.input.sql
+++ b/tests/fixtures/create_table/inline_primary_key.input.sql
@@ -1,0 +1,7 @@
+CREATE TABLE orders
+(
+   order_id   integer NOT NULL PRIMARY KEY
+  ,customer   text    NOT NULL
+  ,total      decimal
+)
+;

--- a/tests/fixtures/create_table/simple_no_constraints.expected.sql
+++ b/tests/fixtures/create_table/simple_no_constraints.expected.sql
@@ -1,0 +1,7 @@
+CREATE TABLE person
+(
+   id   INT  NOT NULL
+  ,name TEXT
+  ,age  INT
+)
+;

--- a/tests/fixtures/create_table/simple_no_constraints.expected.sql
+++ b/tests/fixtures/create_table/simple_no_constraints.expected.sql
@@ -1,7 +1,7 @@
 CREATE TABLE person
 (
-   id   INT  NOT NULL
-  ,name TEXT
-  ,age  INT
+   id   int  NOT NULL
+  ,name text
+  ,age  int
 )
 ;

--- a/tests/fixtures/create_table/simple_no_constraints.input.sql
+++ b/tests/fixtures/create_table/simple_no_constraints.input.sql
@@ -1,0 +1,2 @@
+create table person (id integer not null, name text, age integer)
+;

--- a/tests/fixtures/duckdb/type_cast.expected.sql
+++ b/tests/fixtures/duckdb/type_cast.expected.sql
@@ -1,6 +1,6 @@
 SELECT
-   a::INT
-  ,b::TEXT
-  ,c::BOOLEAN
+   a::int
+  ,b::text
+  ,c::boolean
 FROM t
 ;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Implements the `CREATE TABLE` formatting and lowercase data type rules tracked in #26.

### Changes

**`src/jarify/generator.py`**

- `schema_sql` — puts the opening `(` on its own line when in pretty mode, consistent with the existing CTE layout rule.
- `schema_columns_sql` — splits column definitions from table-level constraints, computes column-name and type alignment widths, renders columns padded to align all type and constraint tokens, and inserts a blank line before table-level constraints (`PRIMARY KEY`, `UNIQUE`, `CHECK`, etc.) when present.
- `columndef_sql` — honours the two alignment widths stored during `schema_columns_sql`; falls back to default behaviour outside `CREATE TABLE` (e.g. `ALTER TABLE ADD COLUMN`).
- `datatype_sql` — lowercases all data type names (`text`, `int`, `timestamp`, `decimal`, etc.) while leaving SQL statement keywords (`SELECT`, `FROM`, `NOT NULL`, `DEFAULT`, `PRIMARY KEY`, etc.) uppercase.

**`tests/fixtures/create_table/`**

Three new fixture pairs:

| Fixture | What it covers |
|---|---|
| `basic` | Full DDL: mixed custom/built-in types, `DEFAULT`, nullable columns, table-level `PRIMARY KEY` |
| `simple_no_constraints` | Plain table with no constraints; verifies no blank line is added |
| `inline_primary_key` | Column-level `PRIMARY KEY` constraint; verifies no blank line is added |

**`tests/fixtures/duckdb/type_cast.expected.sql`** — updated to lowercase types (`int`, `text`, `boolean`).

**`docs/sql-style-guide.md`** — adds `CREATE TABLE` layout rule and updates the Keywords section to document the keyword-uppercase / type-lowercase split.

Resolves #26
