### PR TITLE
feat(generator): uppercase aggregate and window function names

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -51,20 +51,24 @@ CREATE TABLE t
 
 ---
 
-### Functions — lowercase
+### Functions — aggregate and window uppercase, scalar lowercase
 
-DuckDB built-in functions are always lowercase.
+Aggregate and window functions (`COUNT`, `SUM`, `AVG`, `ROW_NUMBER`, `RANK`, `LEAD`, etc.) are always uppercase. All other DuckDB built-in functions (`regexp_extract`, `strftime`, `date_trunc`, etc.) remain lowercase.
 
 **Bad**
 ```sql
-SELECT REGEXP_EXTRACT(file, 'version=(.{21})', 1) AS version FROM GLOB('s3://bucket/*/*')
+SELECT COUNT(*), SUM(amount), row_number() OVER (ORDER BY ts), REGEXP_EXTRACT(x, '[0-9]+'), STRFTIME(ts, '%Y') FROM t
 ```
 
 **Good**
 ```sql
 SELECT
-   regexp_extract(file, 'version=(.{21})', 1) AS version
-FROM glob('s3://bucket/*/*')
+   COUNT(*)
+  ,SUM(amount)
+  ,ROW_NUMBER() OVER (ORDER BY ts)
+  ,regexp_extract(x, '[0-9]+')
+  ,strftime(ts, '%Y')
+FROM t
 ;
 ```
 
@@ -171,11 +175,11 @@ The same inline rule applies to `HAVING`:
 ```sql
 SELECT
    a
-  ,count(*) AS n
+  ,COUNT(*) AS n
 FROM t
 GROUP BY
    a
-HAVING count(*) > 1
+HAVING COUNT(*) > 1
    AND a IS NOT NULL
 ;
 ```
@@ -188,7 +192,7 @@ Every `GROUP BY` expression is on its own line using the same leading-comma styl
 
 **Bad**
 ```sql
-SELECT a, b, count(*) FROM t GROUP BY a, b
+SELECT a, b, COUNT(*) FROM t GROUP BY a, b
 ```
 
 **Good**
@@ -196,7 +200,7 @@ SELECT a, b, count(*) FROM t GROUP BY a, b
 SELECT
    a
   ,b
-  ,count(*)
+  ,COUNT(*)
 FROM t
 GROUP BY
    a
@@ -210,7 +214,7 @@ GROUP BY
 SELECT
    a
   ,b
-  ,count(*)
+  ,COUNT(*)
 FROM t
 GROUP BY ALL
 ;
@@ -440,17 +444,17 @@ FROM sku_composition
 
 ### `DISTINCT` inside aggregates — own line when wrapping
 
-When `array_agg(DISTINCT expr ...)` wraps across lines, `DISTINCT` appears on its own line.
+When `ARRAY_AGG(DISTINCT expr ...)` wraps across lines, `DISTINCT` appears on its own line.
 
 **Bad**
 ```sql
-SELECT array_agg(DISTINCT (active_ingredient_key, quantity, uom_key)::active_ingredient_struct) FROM t
+SELECT ARRAY_AGG(DISTINCT (active_ingredient_key, quantity, uom_key)::active_ingredient_struct) FROM t
 ```
 
 **Good**
 ```sql
 SELECT
-   array_agg(
+   ARRAY_AGG(
     DISTINCT (
        active_ingredient_key
       ,quantity
@@ -659,7 +663,7 @@ WHERE rn = 1
 ```sql
 SELECT
    a
-  ,row_number() OVER (PARTITION BY b ORDER BY c) AS rn
+  ,ROW_NUMBER() OVER (PARTITION BY b ORDER BY c) AS rn
 FROM t
 QUALIFY
   rn = 1
@@ -674,7 +678,7 @@ Flag explicit `GROUP BY col1, col2, ...` when all non-aggregated `SELECT` column
 
 **Bad**
 ```sql
-SELECT a, b, count(*) AS n FROM t GROUP BY a, b
+SELECT a, b, COUNT(*) AS n FROM t GROUP BY a, b
 ```
 
 **Good**
@@ -682,7 +686,7 @@ SELECT a, b, count(*) AS n FROM t GROUP BY a, b
 SELECT
    a
   ,b
-  ,count(*) AS n
+  ,COUNT(*) AS n
 FROM t
 GROUP BY ALL
 ;

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -16,6 +16,8 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - DISTINCT inside aggregates appears on its own line when the call wraps
 - CREATE TABLE: opening paren on its own line, column name/type alignment,
   blank line before table-level constraints
+- Aggregate and window functions (COUNT, SUM, ROW_NUMBER, RANK, …) are uppercase;
+  all other DuckDB built-in functions remain lowercase
 """
 
 from __future__ import annotations
@@ -39,6 +41,35 @@ class JarifyGenerator(DuckDB.Generator):
     # We remove it so the dispatch falls through to pivot_sql directly, preserving qualifiers.
     TRANSFORMS: ClassVar[dict] = {k: v for k, v in DuckDB.Generator.TRANSFORMS.items() if k is not exp.Pivot}
 
+    # Aggregate and window function names that should be uppercased in output.
+    # Derived from sqlglot's AggFunc hierarchy + RowNumber (window-only) + the
+    # DuckDB-dialect names for functions that get renamed by the dialect layer
+    # (e.g. VariancePop → "var_pop", PercentileCont → "quantile_cont").
+    _UPPERCASE_FUNCS: ClassVar[frozenset[str]] = (
+        frozenset(
+            cls.sql_name().lower()
+            for _, cls in vars(exp).items()
+            if isinstance(cls, type) and issubclass(cls, exp.AggFunc) and cls is not exp.AggFunc
+        )
+        | frozenset(["row_number"])
+        | frozenset(
+            [
+                # DuckDB renames these aggregate expressions; add the dialect output
+                # names so normalize_func can uppercase them too.
+                "approx_count_distinct",  # ApproxDistinct
+                "bool_and",               # LogicalAnd
+                "bool_or",                # LogicalOr
+                "boolxor",                # BoolxorAgg
+                "json_arrayagg",          # JSONArrayAgg
+                "json_group_object",      # JSONObjectAgg / JSONBObjectAgg
+                "listagg",                # GroupConcat
+                "quantile_cont",          # PercentileCont
+                "quantile_disc",          # PercentileDisc
+                "var_pop",                # VariancePop
+            ]
+        )
+    )
+
     def __init__(self, config: JarifyConfig) -> None:
         super().__init__(
             pretty=True,
@@ -54,6 +85,13 @@ class JarifyGenerator(DuckDB.Generator):
         self._as_align_width: int | None = None  # set during SELECT expression rendering
         self._col_name_align: int | None = None  # set during CREATE TABLE column rendering
         self._col_type_align: int | None = None  # set during CREATE TABLE column rendering
+
+    # ------------------------------------------------------------------
+    # Function name casing: aggregates/window functions → UPPER, rest → lower
+    # ------------------------------------------------------------------
+
+    def normalize_func(self, name: str) -> str:
+        return name.upper() if name.lower() in self._UPPERCASE_FUNCS else name.lower()
 
     # ------------------------------------------------------------------
     # Leading-comma style: ,col  (comma at pad, content at pad+1)
@@ -357,14 +395,15 @@ class JarifyGenerator(DuckDB.Generator):
             return super().arrayagg_sql(expression)
         distinct = expression.this
         exprs_sqls = [self.sql(e) for e in distinct.expressions]
+        func_name = self.normalize_func("ARRAY_AGG")
         # Wrap when any expression is already multi-line, or when the flat inline is too wide
         any_multiline = any("\n" in s for s in exprs_sqls)
-        flat_inline = f"array_agg(DISTINCT {', '.join(exprs_sqls)})"
+        flat_inline = f"{func_name}(DISTINCT {', '.join(exprs_sqls)})"
         if not any_multiline and not self.too_wide([flat_inline]):
             return super().arrayagg_sql(expression)
         exprs_str = "\n".join(exprs_sqls)
         inner = self.indent(f"\nDISTINCT {exprs_str}\n", skip_first=True, skip_last=True)
-        array_agg_sql = f"array_agg({inner})"
+        array_agg_sql = f"{func_name}({inner})"
         return self._add_arrayagg_null_filter(array_agg_sql, expression, expression.this)
 
     def format_args(self, *args: t.Any, sep: str = ", ") -> str:

--- a/tests/fixtures/duckdb/agg_window_uppercase.expected.sql
+++ b/tests/fixtures/duckdb/agg_window_uppercase.expected.sql
@@ -1,0 +1,12 @@
+SELECT
+   COUNT(*)                                                     AS total
+  ,SUM(amount)                                                  AS total_amount
+  ,AVG(price)                                                   AS avg_price
+  ,ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at) AS rn
+  ,RANK() OVER (ORDER BY amount DESC)                           AS rnk
+  ,LAG(amount, 1) OVER (ORDER BY created_at)                    AS prev_amount
+  ,regexp_extract(description, '[A-Z]{3}-\d+')                  AS code
+  ,strftime(created_at, '%Y-%m')                                AS month
+  ,date_trunc('WEEK', created_at)                               AS week_start
+FROM orders
+;

--- a/tests/fixtures/duckdb/agg_window_uppercase.input.sql
+++ b/tests/fixtures/duckdb/agg_window_uppercase.input.sql
@@ -1,0 +1,11 @@
+SELECT
+  count(*) AS total,
+  sum(amount) AS total_amount,
+  avg(price) AS avg_price,
+  row_number() OVER (PARTITION BY user_id ORDER BY created_at) AS rn,
+  rank() OVER (ORDER BY amount DESC) AS rnk,
+  lag(amount, 1) OVER (ORDER BY created_at) AS prev_amount,
+  regexp_extract(description, '[A-Z]{3}-\d+', 0) AS code,
+  strftime(created_at, '%Y-%m') AS month,
+  date_trunc('week', created_at) AS week_start
+FROM orders

--- a/tests/fixtures/duckdb/distinct_in_aggregates.expected.sql
+++ b/tests/fixtures/duckdb/distinct_in_aggregates.expected.sql
@@ -1,5 +1,5 @@
 SELECT
-   array_agg(
+   ARRAY_AGG(
     DISTINCT (
        active_ingredient_key
       ,quantity

--- a/tests/fixtures/duckdb/pivot.expected.sql
+++ b/tests/fixtures/duckdb/pivot.expected.sql
@@ -1,5 +1,5 @@
 FROM t
-PIVOT(sum(amount) FOR  category IN ( 'A'
+PIVOT(SUM(amount) FOR  category IN ( 'A'
     ,'B'
 ,'C'))
 ;

--- a/tests/fixtures/duckdb/pivot_order_by.expected.sql
+++ b/tests/fixtures/duckdb/pivot_order_by.expected.sql
@@ -14,7 +14,7 @@ PIVOT (
   FROM _data
 )
 ON participant_key
-USING first(enrolled)
+USING FIRST(enrolled)
 ORDER BY
    program_key
   ,participant_key

--- a/tests/fixtures/duckdb/qualify.expected.sql
+++ b/tests/fixtures/duckdb/qualify.expected.sql
@@ -1,6 +1,6 @@
 SELECT
    a
-  ,row_number() OVER (PARTITION BY b ORDER BY c) AS rn
+  ,ROW_NUMBER() OVER (PARTITION BY b ORDER BY c) AS rn
 FROM t
 QUALIFY
   rn = 1


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by GitHub Copilot CLI (powered by Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Implements uppercase aggregate and window function names as specified in #28.

**Before:**
```sql
SELECT
   count(*)
  ,sum(amount)
  ,row_number() OVER (PARTITION BY id ORDER BY ts)
  ,array_agg(DISTINCT sku ORDER BY sku)
FROM t
```

**After:**
```sql
SELECT
   COUNT(*)
  ,SUM(amount)
  ,ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts)
  ,ARRAY_AGG(DISTINCT sku ORDER BY sku)
FROM t
```

Scalar functions remain lowercase: `regexp_extract`, `strftime`, `read_parquet`, etc.

## Implementation

- `src/jarify/generator.py`: Added `_UPPERCASE_FUNCS: ClassVar[frozenset[str]]` derived from sqlglot's `AggFunc` subclass hierarchy plus `RowNumber`. A supplemental set covers DuckDB dialect renames (`var_pop`, `quantile_cont`, `listagg`, `bool_or`, etc.). `normalize_func` override checks this set and uppercases/lowercases accordingly. `arrayagg_sql` hardcoded `"array_agg"` in two places — replaced with `self.normalize_func("ARRAY_AGG")`.
- `tests/fixtures/duckdb/agg_window_uppercase.{input,expected}.sql`: New fixture pair covering the full range of aggregate and window functions.
- Updated 4 existing fixture snapshots.
- `docs/sql-style-guide.md`: Renamed "Functions — lowercase" section to "aggregate and window uppercase, scalar lowercase" with updated examples. Fixed `count`, `row_number`, `array_agg` references throughout.

Resolves #28
