### PR TITLE
Fix broken Rich markup in lint violation count summary

### DIFF
--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -145,7 +145,8 @@ def lint(
         total_violations += len(violations)
 
     if total_violations:
-        console.print(f"\n[bold]{'red' if has_errors else 'yellow'}]{total_violations} violation(s) found[/]")
+        color = "red" if has_errors else "yellow"
+        console.print(f"\n[bold {color}]{total_violations} violation(s) found[/]")
         sys.exit(1)
     else:
         console.print("[bold green]All clean![/]")


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fix broken Rich markup in the `jarify lint` violation count summary line.

The f-string in `cli.py` resolved to `[bold]red]N violation(s) found[/]` — Rich treated `red]` as literal text, so the count rendered unstyled as `red]12 violation(s) found`. Extracted the color into a variable and used `[bold {color}]` to produce a valid Rich tag.

**Before:**
```python
console.print(f"\n[bold]{'red' if has_errors else 'yellow'}]{total_violations} violation(s) found[/]")
```

**After:**
```python
color = "red" if has_errors else "yellow"
console.print(f"\n[bold {color}]{total_violations} violation(s) found[/]")
```

Resolves #36
