### PR TITLE
Surface actual parse error in fmt fallback warning instead of blaming PIVOT

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -39,16 +39,12 @@ def format_sql(
 
     try:
         trees = parse_sql(sql, dialect=config.dialect)
-    except ParseError:
+    except ParseError as exc:
         result = _try_pivot_order_by_workaround(sql, config)
         if result is not None:
             return result, warnings
         warnings.append(
-            FormatWarning(
-                "could not parse SQL (formatting skipped): "
-                "unsupported syntax — PIVOT with ORDER BY is a known limitation "
-                "tracked in https://github.com/amfaro/jarify/issues/2"
-            )
+            FormatWarning(f"could not parse SQL (formatting skipped): {exc}")
         )
         return sql, warnings
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -65,6 +65,15 @@ def test_parse_failure_returns_original_with_warning():
     assert "could not parse" in str(warnings[0])
 
 
+def test_parse_failure_warning_includes_actual_error_not_pivot_message():
+    """Warning for non-PIVOT parse failures must not mention PIVOT or issues/2."""
+    bad_sql = "THIS IS NOT VALID SQL @@@!!!"
+    _, warnings = format_sql(bad_sql)
+    msg = str(warnings[0])
+    assert "PIVOT" not in msg
+    assert "issues/2" not in msg
+
+
 def test_pivot_order_by_formats_without_warning():
     """PIVOT ... USING ... ORDER BY is formatted cleanly without any warning."""
     sql = (


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fix the hardcoded PIVOT blame message in `jarify fmt` when formatting fails for unrelated reasons.

Previously, any `ParseError` that wasn't handled by the PIVOT+ORDER BY workaround produced this confusing output:

```
could not parse SQL (formatting skipped): unsupported syntax — PIVOT with ORDER BY is a known limitation tracked in https://github.com/amfaro/jarify/issues/2
```

Now the actual `ParseError` message is surfaced, so users see the real reason formatting was skipped (e.g. `[]::filter[]` inside a CASE expression).

**Change:** `src/jarify/formatter.py` — capture `ParseError as exc` and use `f"could not parse SQL (formatting skipped): {exc}"`.

**Test added:** `test_parse_failure_warning_includes_actual_error_not_pivot_message` asserts `"PIVOT"` and `"issues/2"` are absent from non-PIVOT failure warnings.

Resolves #35
