### PR TITLE
Suppress noisy sqlglot stderr output in lenient parser

### DIFF
--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -23,8 +23,10 @@ def parse_sql_lenient(sql: str, dialect: str = DUCKDB_DIALECT) -> tuple[list[Exp
     try:
         trees = sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
     except ParseError:
-        # Fall back to lenient parsing so we still get partial trees
-        trees = sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.WARN)
+        # Fall back to lenient parsing so we still get partial trees.
+        # Use IGNORE (not WARN) to suppress sqlglot's side-effect stderr prints;
+        # errors are re-captured via the RAISE pass below.
+        trees = sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.IGNORE)
         # Re-parse to capture the actual errors
         try:
             sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,8 @@
 """Tests for the SQL parser module."""
 
+import io
+import sys
+
 from jarify.parser import parse_sql, parse_sql_lenient
 
 
@@ -23,3 +26,15 @@ def test_parse_lenient_collects_errors():
     _, errors = parse_sql_lenient("SELECT FROM WHERE")
     # Should parse leniently without raising
     assert isinstance(errors, list)
+
+
+def test_parse_lenient_emits_nothing_to_stderr():
+    """ErrorLevel.WARN side-effect must not bleed through to the caller's stderr."""
+    captured = io.StringIO()
+    old_stderr = sys.stderr
+    sys.stderr = captured
+    try:
+        parse_sql_lenient("THIS IS NOT VALID SQL @@@!!!")
+    finally:
+        sys.stderr = old_stderr
+    assert captured.getvalue() == "", f"Unexpected stderr output: {captured.getvalue()!r}"


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Stop `jarify lint` from flooding stderr with dozens of duplicate raw sqlglot parse warnings when a file fails to parse.

**Root cause:** `parse_sql_lenient` used `ErrorLevel.WARN`, which causes sqlglot to print each individual sub-error to stderr as a side effect. The same errors were then re-captured via the `RAISE` pass immediately below — making the raw stderr output pure redundant noise.

**Fix:** Switch the lenient fallback pass to `ErrorLevel.IGNORE`. The `RAISE` re-parse pass still captures all errors correctly, so no diagnostic information is lost and jarify's own formatted `[ERROR]` violation line is the only output.

**Before:** tens of raw sqlglot lines like `Expected type. Line 333, Col: 57` printed before any formatted output.  
**After:** silent lenient pass → single clean `[ERROR] parse-error` violation in the lint report.

**Test added:** `test_parse_lenient_emits_nothing_to_stderr` asserts stderr is empty when `parse_sql_lenient` is called on invalid input.

Resolves #34
