### PR TITLE
Handle reserved keywords used as DuckDB cast type names (fixes ::filter[] parse failure)

### DIFF
--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import functools
+import re
+
 import sqlglot
 from sqlglot.errors import ParseError
 from sqlglot.expressions import Expression
@@ -9,27 +12,87 @@ from sqlglot.expressions import Expression
 DUCKDB_DIALECT = "duckdb"
 
 
+# ---------------------------------------------------------------------------
+# Reserved-keyword type-cast pre-processor
+# ---------------------------------------------------------------------------
+# DuckDB allows user-defined types whose names are SQL reserved words, e.g.
+#   COALESCE(x, []::filter[])
+# sqlglot fails to parse these because it sees ``filter`` as a keyword token,
+# not a type name.  Quoting them — ``::"filter"[]`` — makes sqlglot parse
+# correctly; the generator then emits the unquoted ``::filter[]`` form again.
+
+
+@functools.lru_cache(maxsize=1)
+def _reserved_cast_re() -> re.Pattern[str]:
+    """Return a compiled regex that matches ``::keyword`` cast type names
+    where the keyword is a DuckDB reserved word that sqlglot cannot parse as
+    an unquoted type.  Result is cached so the build only happens once per
+    process.
+    """
+    from sqlglot.dialects.duckdb import DuckDB
+    from sqlglot.tokens import TokenType
+
+    tokenizer = DuckDB.Tokenizer()
+    type_tokens = DuckDB.Parser.TYPE_TOKENS
+
+    reserved: list[str] = []
+    for kw in DuckDB.Tokenizer.KEYWORDS:
+        word = kw.strip().lower()
+        if not word.isalpha():
+            continue
+        toks = tokenizer.tokenize(word)
+        if not toks:
+            continue
+        tt = toks[0].token_type
+        # VAR = plain identifier; TYPE_TOKENS = sqlglot-recognised type tokens.
+        # Both are safe as unquoted type names; everything else needs quoting.
+        if tt != TokenType.VAR and tt not in type_tokens:
+            reserved.append(word)
+
+    words_pat = "|".join(re.escape(w) for w in sorted(reserved, key=len, reverse=True))
+    # Match ::keyword or ::keyword[] but NOT ::keyword_something (word boundary via (?!\w))
+    return re.compile(rf"::({words_pat})(\[\])?(?!\w)", re.IGNORECASE)
+
+
+def _quote_reserved_cast_types(sql: str) -> str:
+    """Quote reserved keywords used as cast type names so sqlglot can parse them.
+
+    ``[]::filter[]`` → ``[]::"filter"[]``
+
+    The generator round-trips this back to the unquoted ``::filter[]`` form.
+    """
+
+    def _replacer(m: re.Match[str]) -> str:
+        return f'::"{ m.group(1)}"{m.group(2) or ""}'
+
+    return _reserved_cast_re().sub(_replacer, sql)
+
+
 def parse_sql(sql: str, dialect: str = DUCKDB_DIALECT) -> list[Expression]:
     """Parse a SQL string into a list of sqlglot expression trees.
 
-    Raises ParseError if the SQL is invalid.
+    Raises ParseError if the SQL is invalid.  Applies a pre-processing step
+    to quote DuckDB reserved keywords used as cast type names (e.g.
+    ``::filter[]``) so sqlglot can handle them.
     """
-    return sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
+    preprocessed = _quote_reserved_cast_types(sql)
+    return sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
 
 
 def parse_sql_lenient(sql: str, dialect: str = DUCKDB_DIALECT) -> tuple[list[Expression], list[ParseError]]:
     """Parse SQL leniently, collecting errors instead of raising."""
+    preprocessed = _quote_reserved_cast_types(sql)
     errors: list[ParseError] = []
     try:
-        trees = sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
+        trees = sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
     except ParseError:
         # Fall back to lenient parsing so we still get partial trees.
         # Use IGNORE (not WARN) to suppress sqlglot's side-effect stderr prints;
         # errors are re-captured via the RAISE pass below.
-        trees = sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.IGNORE)
+        trees = sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.IGNORE)
         # Re-parse to capture the actual errors
         try:
-            sqlglot.parse(sql, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
+            sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
         except ParseError as e:
             errors.append(e)
     return trees, errors

--- a/tests/fixtures/duckdb/reserved_keyword_type_cast.expected.sql
+++ b/tests/fixtures/duckdb/reserved_keyword_type_cast.expected.sql
@@ -1,0 +1,21 @@
+SELECT
+   CASE x
+    WHEN 'a'
+    THEN (
+       y
+      ,array_transform(coalesce(z, []::filter[]), f -> (
+         f.a
+        ,f.b
+      )::s)
+    )::mystruct::json
+    WHEN 'b'
+    THEN (
+       y
+      ,array_transform(coalesce(z, []::filter[]), f -> (
+         f.a
+        ,f.b
+      )::s)
+    )::mystruct::json
+  END AS result
+FROM t
+;

--- a/tests/fixtures/duckdb/reserved_keyword_type_cast.input.sql
+++ b/tests/fixtures/duckdb/reserved_keyword_type_cast.input.sql
@@ -1,0 +1,13 @@
+SELECT
+   CASE x
+    WHEN 'a' THEN (
+       y
+      ,array_transform(COALESCE(z, []::filter[]), f -> (f.a, f.b)::s)
+    )::mystruct::json
+    WHEN 'b' THEN (
+       y
+      ,array_transform(COALESCE(z, []::filter[]), f -> (f.a, f.b)::s)
+    )::mystruct::json
+   END AS result
+FROM t
+;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,9 @@
 import io
 import sys
 
-from jarify.parser import parse_sql, parse_sql_lenient
+import pytest
+
+from jarify.parser import _quote_reserved_cast_types, parse_sql, parse_sql_lenient
 
 
 def test_parse_simple_select():
@@ -38,3 +40,57 @@ def test_parse_lenient_emits_nothing_to_stderr():
     finally:
         sys.stderr = old_stderr
     assert captured.getvalue() == "", f"Unexpected stderr output: {captured.getvalue()!r}"
+
+
+class TestReservedKeywordTypeCasts:
+    """::reserved_keyword[] cast type names must parse and round-trip correctly."""
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT []::filter[]",
+            "SELECT COALESCE(x, []::filter[])",
+            "SELECT array_transform(COALESCE(x, []::filter[]), f -> f.a)",
+            "SELECT CASE WHEN 1=1 THEN []::filter[] END",
+            "SELECT x::filter",
+        ],
+    )
+    def test_reserved_type_name_parses(self, sql: str) -> None:
+        """Queries using reserved keywords as type names must not raise."""
+        trees = parse_sql(sql)
+        assert len(trees) == 1
+        assert trees[0] is not None
+
+    def test_non_reserved_type_name_unchanged(self) -> None:
+        """Non-reserved type names must not be altered by the pre-processor."""
+        sql = "SELECT []::my_struct[], x::text, y::int"
+        assert _quote_reserved_cast_types(sql) == sql
+
+    def test_reserved_type_name_quoted(self) -> None:
+        assert _quote_reserved_cast_types("SELECT []::filter[]") == 'SELECT []::"filter"[]'
+
+    def test_reserved_type_name_no_array_suffix_quoted(self) -> None:
+        assert _quote_reserved_cast_types("SELECT x::filter") == 'SELECT x::"filter"'
+
+    def test_filter_inside_case_parses(self) -> None:
+        """The exact pattern from real-world DuckDB macros must parse cleanly."""
+        sql = """
+        SELECT CASE x
+          WHEN 'a' THEN (
+             y
+            ,array_transform(
+               COALESCE(z, []::filter[]),
+               f -> (f.a, f.b)::s
+             )
+          )::mystruct::json
+        END
+        """
+        trees = parse_sql(sql)
+        assert len(trees) == 1
+        assert trees[0] is not None
+
+    def test_already_quoted_left_unchanged(self) -> None:
+        """Already-quoted type names must not be double-quoted."""
+        sql = 'SELECT []::"filter"[]'
+        result = _quote_reserved_cast_types(sql)
+        assert '""' not in result


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fix `jarify lint` and `jarify fmt` crashing on SQL files that use DuckDB reserved keywords as user-defined type names in cast expressions (e.g. `[]::filter[]`).

## Root cause

DuckDB allows user-defined types whose names are SQL reserved words. `filter` is a common example — teams create a `filter` struct type alongside DuckDB's built-in `FILTER (WHERE ...)` aggregate clause. sqlglot tokenises `filter` as a `FILTER` keyword token rather than an identifier, so `[]::filter[]` fails with `Expected type` regardless of context.

## Fix

Add a pre-processing step in `src/jarify/parser.py` that quotes reserved keywords in cast type-name positions before handing the SQL to sqlglot:

| Stage | SQL |
|---|---|
| Input | `COALESCE(x, []::filter[])` |
| Parser input | `COALESCE(x, []::"filter"[])` |
| Generator output | `COALESCE(x, []::filter[])` ✓ |

The set of keywords needing quoting is computed **once per process (~0.4 ms)** using sqlglot's own tokeniser: any keyword whose token type is neither `TokenType.VAR` nor a member of `Parser.TYPE_TOKENS` is quoted. The result is cached via `lru_cache`.

## Verification

- `get_programs.sql` (the original repro file) now lints cleanly — only real style warnings, zero parse errors.
- 109 tests pass, ruff clean.
- New fixture `duckdb/reserved_keyword_type_cast` covers the `::filter[]`-in-CASE pattern.
- New parser unit tests cover quoting, non-quoting, already-quoted, and real-world patterns.

Resolves #37
