### PR TITLE
Fix CREATE MACRO parameter list formatting

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -570,6 +570,31 @@ CREATE OR REPLACE TABLE examples
 
 ---
 
+### `CREATE MACRO` layout
+
+The opening parenthesis of the parameter list goes on its own line. Parameters use the standard leading-comma style: the first parameter is indented three spaces, subsequent parameters use two spaces plus a leading comma.
+
+**Bad**
+```sql
+CREATE OR REPLACE MACRO get_programs_json(_participant_key, _time_frame, _program_supplier_key) AS (SELECT 1)
+```
+
+**Good**
+```sql
+CREATE OR REPLACE MACRO get_programs_json
+(
+   _participant_key
+  ,_time_frame
+  ,_program_supplier_key
+) AS
+(
+  SELECT 1
+)
+;
+```
+
+---
+
 ## Lint Rules
 
 Lint rules report violations but do not modify the SQL. All rules default to `warn`. Severity can be set to `off`, `warn`, or `error` in `jarify.toml`.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -561,6 +561,24 @@ class JarifyGenerator(DuckDB.Generator):
         return super().datatype_sql(expression).lower()
 
     # ------------------------------------------------------------------
+    # CREATE MACRO: opening paren on its own line, leading-comma params
+    # ------------------------------------------------------------------
+
+    def userdefinedfunction_sql(self, expression: exp.UserDefinedFunction) -> str:
+        this = self.sql(expression, "this")
+        if not expression.args.get("wrapped") or not self.pretty:
+            return super().userdefinedfunction_sql(expression)
+
+        # Pretty + wrapped: build param list without indentation to avoid the
+        # double-indent that occurs when self.wrap() re-indents an already-indented
+        # string produced by self.expressions().  Apply a single indent pass here.
+        params = self.no_identify(self.expressions, expression, indent=False)
+        if not params.strip():
+            return this
+        indented = self.indent(params)
+        return f"{this}\n(\n{indented}\n)"
+
+    # ------------------------------------------------------------------
     # CREATE TABLE: opening paren on its own line, column alignment,
     # blank line before table-level constraints
     # ------------------------------------------------------------------

--- a/tests/fixtures/duckdb/create_macro.expected.sql
+++ b/tests/fixtures/duckdb/create_macro.expected.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE MACRO get_programs_json
+(
+   _participant_key
+  ,_time_frame
+  ,_program_supplier_key
+) AS
+(
+  SELECT
+     json_object('programs', json_group_array(json_object('name', program_name, 'supplier', supplier_name)))
+  FROM programs
+  WHERE participant_key = _participant_key
+    AND time_frame = _time_frame
+    AND supplier_key = _program_supplier_key
+)
+;

--- a/tests/fixtures/duckdb/create_macro.input.sql
+++ b/tests/fixtures/duckdb/create_macro.input.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE MACRO get_programs_json(_participant_key, _time_frame, _program_supplier_key) AS (SELECT json_object('programs', json_group_array(json_object('name', program_name, 'supplier', supplier_name))) FROM programs WHERE participant_key = _participant_key AND time_frame = _time_frame AND supplier_key = _program_supplier_key);


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes CREATE MACRO parameter list formatting (issue #42).

**Opening paren on its own line** — the `(` of the parameter list appears on its own line, consistent with the `CREATE TABLE` convention.

**Correct indentation** — parameters use jarify's standard leading-comma style (3 spaces for the first item, 2 spaces + comma for subsequent items). Previously `self.wrap()` applied a second indent on top of `self.expressions()`, producing 5-space / 4+comma alignment.

## Changes

- `src/jarify/generator.py` — new `userdefinedfunction_sql` override: builds param list with `indent=False` to avoid double-indentation, applies a single `self.indent()` pass, emits `{name}\n(\n{params}\n)`
- `tests/fixtures/duckdb/create_macro.{input,expected}.sql` — new fixture
- `docs/sql-style-guide.md` — added CREATE MACRO formatting section

Resolves #42