### PR TITLE
Fix VALUES CTE formatting

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -595,6 +595,33 @@ CREATE OR REPLACE MACRO get_programs_json
 
 ---
 
+### `VALUES` CTE layout
+
+A `WITH` clause CTE whose body is a plain `VALUES` list is rendered as `VALUES` (not `FROM (VALUES ...) AS ...`). Rows use leading-comma style. Each non-last column is right-padded with spaces after its comma so that the next column aligns across all rows. CTE names that declare column aliases include a space before the column list.
+
+**Bad**
+```sql
+WITH _lookup (code, label) AS (VALUES ('a', 'active'), ('i', 'inactive'))
+SELECT code, label FROM _lookup
+```
+
+**Good**
+```sql
+WITH _lookup (code, label) AS
+(
+  VALUES
+     ('a', 'active'  )
+    ,('i', 'inactive')
+)
+SELECT
+   code
+  ,label
+FROM _lookup
+;
+```
+
+---
+
 ## Lint Rules
 
 Lint rules report violations but do not modify the SQL. All rules default to `warn`. Severity can be set to `off`, `warn`, or `error` in `jarify.toml`.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -195,8 +195,24 @@ class JarifyGenerator(DuckDB.Generator):
         return f"{this_sql} AS {alias_name}"
 
     # ------------------------------------------------------------------
-    # CTE formatting: paren on its own line, comma-prefix separator
+    # CTE formatting: paren on its own line, comma-prefix separator;
+    # table alias with columns gets a space before the column list
     # ------------------------------------------------------------------
+
+    def tablealias_sql(self, expression: exp.TableAlias) -> str:
+        alias = self.sql(expression, "this")
+        columns = self.expressions(expression, key="columns", flat=True)
+        columns_sql = f"({columns})" if columns else ""
+
+        if columns_sql and not self.SUPPORTS_TABLE_ALIAS_COLUMNS:
+            columns_sql = ""
+            self.unsupported("Named columns are not supported in table alias.")
+
+        if not alias and not self.dialect.UNNEST_COLUMN_ONLY:
+            alias = self._next_name()
+
+        # Add a space between name and column list: "t (a, b)" not "t(a, b)"
+        return f"{alias} {columns_sql}" if alias and columns_sql else f"{alias}{columns_sql}"
 
     def cte_sql(self, expression: exp.CTE) -> str:
         alias = expression.args.get("alias")
@@ -475,6 +491,23 @@ class JarifyGenerator(DuckDB.Generator):
             self._join_alias_col = self._compute_join_align_width(expression)
         try:
             exprs = expression.expressions
+            from_ = expression.args.get("from_")
+
+            # Detect VALUES-only CTE body: SELECT * FROM (VALUES ...) AS _values
+            # sqlglot parses `WITH t(a,b) AS (VALUES ...)` into this shape; render
+            # it back to a plain VALUES block instead of FROM (VALUES ...) AS _values.
+            if (
+                self.pretty
+                and self._config.prefer_from_first
+                and len(exprs) == 1
+                and isinstance(exprs[0], exp.Star)
+                and not expression.args.get("distinct")
+                and not expression.args.get("joins")
+                and isinstance(from_, exp.From)
+                and isinstance(from_.this, exp.Values)
+            ):
+                return self._cte_values_sql(from_.this)
+
             if (
                 self._config.prefer_from_first
                 and len(exprs) == 1
@@ -491,6 +524,53 @@ class JarifyGenerator(DuckDB.Generator):
             return super().select_sql(expression)
         finally:
             self._join_alias_col = saved_align
+
+    def _cte_values_sql(self, expression: exp.Values) -> str:
+        """Render a VALUES block for a CTE body.
+
+        Produces leading-comma row list with column alignment: the first
+        column in each row is padded so that the second (and subsequent)
+        column values align across all rows.
+        """
+        rows = expression.expressions  # list of Tuple nodes
+        if not rows:
+            return "VALUES"
+
+        rendered: list[list[str]] = [
+            [self.sql(cell) for cell in tup.expressions]
+            for tup in rows
+        ]
+
+        num_cols = max(len(r) for r in rendered) if rendered else 0
+        if num_cols == 0:
+            return "VALUES"
+
+        # Max rendered width per non-last column for padding alignment
+        col_widths: list[int] = [
+            max((len(r[col_idx]) for r in rendered if col_idx < len(r)), default=0)
+            for col_idx in range(num_cols - 1)
+        ]
+
+        # Build each row: (val0,<pad>val1,<pad>val2,...,last_val)
+        # The comma follows immediately after each non-last value; trailing
+        # spaces pad up to max_width+1 so the next value aligns.
+        row_sqls: list[str] = []
+        for cells in rendered:
+            parts: list[str] = []
+            for i, cell in enumerate(cells):
+                if i < len(col_widths):
+                    pad = " " * (col_widths[i] - len(cell) + 1)
+                    parts.append(f"{cell},{pad}")
+                else:
+                    parts.append(cell)
+            row_sqls.append(f"({''.join(parts)})")
+
+        # Leading-comma style: first row gets a leading space, rest get comma
+        lines = [f" {row_sqls[0]}"]
+        lines.extend(f",{row}" for row in row_sqls[1:])
+
+        body = self.indent("\n".join(lines))
+        return f"VALUES\n{body}"
 
     # ------------------------------------------------------------------
     # GROUP BY: one expression per line in pretty mode

--- a/tests/fixtures/duckdb/values_cte.expected.sql
+++ b/tests/fixtures/duckdb/values_cte.expected.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE MACRO get_programs_json
+(
+   _participant_key
+  ,_time_frame
+  ,_program_supplier_key
+) AS
+(
+  WITH _qualification_types (qualification_type, style) AS
+  (
+    VALUES
+       ('aggregated_amount',       'aggregation')
+      ,('aggregated_quantity',     'aggregation')
+      ,('brand_count',             'count')
+      ,('property',                'property')
+      ,('yoy_amount_index',        'ratio')
+      ,('yoy_quantity_index',      'ratio')
+      ,('share_of_wallet_percent', 'ratio')
+      ,('amount_average_index',    'ratio')
+  )
+  SELECT
+     qualification_type
+    ,style
+  FROM _qualification_types
+)
+;

--- a/tests/fixtures/duckdb/values_cte.input.sql
+++ b/tests/fixtures/duckdb/values_cte.input.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE MACRO get_programs_json(_participant_key, _time_frame, _program_supplier_key) AS (
+  WITH _qualification_types (qualification_type, style) AS (
+    VALUES ('aggregated_amount', 'aggregation'), ('aggregated_quantity', 'aggregation'), ('brand_count', 'count'), ('property', 'property'), ('yoy_amount_index', 'ratio'), ('yoy_quantity_index', 'ratio'), ('share_of_wallet_percent', 'ratio'), ('amount_average_index', 'ratio')
+  )
+  SELECT qualification_type, style FROM _qualification_types
+);


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes four related issues with `VALUES`-only CTE formatting.

## Root Causes & Fixes

**1. `FROM (VALUES ...) AS _values` wrapping**

sqlglot parses `WITH t(a, b) AS (VALUES ...)` as `SELECT * FROM (VALUES ...) AS _values`. The existing FROM-first transform strips `SELECT *` but left the `FROM (...)` wrapper. Now `select_sql` detects this exact shape and delegates to `_cte_values_sql`, which renders plain `VALUES` rows.

**2. Tuple row expansion**

`tuple_sql` normally wraps multi-value tuples across lines in leading-comma mode. `_cte_values_sql` bypasses `tuple_sql` and renders each row as a single line.

**3. Column alignment**

Each non-last column is right-padded (trailing spaces after its comma) to align the next column across all rows.

**4. CTE name + column list spacing**

Override `tablealias_sql` to emit `name (a, b)` instead of `name(a, b)` when the alias carries a column list.

## Before / After

**Before:**
```sql
WITH _qualification_types(qualification_type, style) AS
(
  FROM (VALUES
     ( "aggregated_amount"
      ,"aggregation")
     ,( "share_of_wallet_percent"
      ,"ratio")
  ) AS _values
)
```

**After:**
```sql
WITH _qualification_types (qualification_type, style) AS
(
  VALUES
     ('aggregated_amount',       'aggregation')
    ,('share_of_wallet_percent', 'ratio')
)
```

## Changes

- `src/jarify/generator.py` — `tablealias_sql` override; `select_sql` VALUES detection; `_cte_values_sql` helper
- `tests/fixtures/duckdb/values_cte.{input,expected}.sql` — fixture pair
- `docs/sql-style-guide.md` — new `VALUES CTE layout` section

Resolves #44
