### PR TITLE
fix(generator): place CTE inline comments after AS as line comments

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -278,6 +278,28 @@ FROM _latest_version
 
 ---
 
+### CTE inline comments — after `AS`
+
+Inline comments on a CTE definition are placed after `AS` on the same line, using `--` style. The opening `(` still goes on its own line below.
+
+**Bad**
+```sql
+WITH _programs /* this is where we filter */ AS
+(
+  SELECT ...
+)
+```
+
+**Good**
+```sql
+WITH _programs AS -- this is where we filter by parameters
+(
+  SELECT ...
+)
+```
+
+---
+
 ### Table aliases — `AS` omitted in `FROM`/`JOIN`, required in `SELECT`
 
 The `AS` keyword is kept for column aliases in `SELECT` lists but **omitted** between a table reference and its alias in `FROM` and `JOIN` lines.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -215,12 +215,19 @@ class JarifyGenerator(DuckDB.Generator):
         return f"{alias} {columns_sql}" if alias and columns_sql else f"{alias}{columns_sql}"
 
     def cte_sql(self, expression: exp.CTE) -> str:
-        alias = expression.args.get("alias")
-        if alias:
-            alias.add_comments(expression.pop_comments())
+        # Pop comments from the CTE node to prevent double-rendering when sql()
+        # calls maybe_comment on the result.  Render them after AS on the same
+        # line: use -- for single-line comments, /* */ for multi-line.
+        comments = expression.pop_comments() or []
         alias_sql = self.sql(expression, "alias")
-        # Put the opening paren on its own line: alias AS\n(...)
-        return f"{alias_sql} AS\n{self.wrap(expression)}"
+        comment_parts: list[str] = []
+        for c in comments:
+            text = c.strip()
+            if not text:
+                continue
+            comment_parts.append(f"/*{c}*/" if "\n" in c else f"-- {text}")
+        comment_suffix = (" " + " ".join(comment_parts)) if comment_parts else ""
+        return f"{alias_sql} AS{comment_suffix}\n{self.wrap(expression)}"
 
     def with_sql(self, expression: exp.With) -> str:
         ctes = expression.expressions

--- a/tests/fixtures/cte/cte_inline_comment.expected.sql
+++ b/tests/fixtures/cte/cte_inline_comment.expected.sql
@@ -1,0 +1,13 @@
+WITH _base AS
+(
+  SELECT
+     1
+)
+,_programs AS -- this is where we filter by parameters
+(
+  SELECT
+     qualification_type
+  FROM _base
+)
+FROM _programs
+;

--- a/tests/fixtures/cte/cte_inline_comment.input.sql
+++ b/tests/fixtures/cte/cte_inline_comment.input.sql
@@ -1,0 +1,6 @@
+WITH _base AS (SELECT 1)
+,_programs AS -- this is where we filter by parameters
+(
+  SELECT qualification_type FROM _base
+)
+SELECT * FROM _programs;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes CTE inline comment placement and style.

## Root Cause

`cte_sql` called `alias.add_comments(expression.pop_comments())` to transfer CTE-node comments onto the alias. `tablealias_sql` then rendered them as `/* */` block comments before `AS`:

```sql
,_programs /* this is where we filter */ AS
(
```

## Fix

Pop comments directly in `cte_sql`, skip moving them to the alias, and emit them after `AS` on the same line. Single-line comments (no embedded newline) use `--`; multi-line use `/* */`.

```sql
,_programs AS -- this is where we filter by parameters
(
```

## Changes

- `src/jarify/generator.py` — rewrite `cte_sql` comment handling
- `tests/fixtures/cte/cte_inline_comment.{input,expected}.sql` — fixture pair
- `docs/sql-style-guide.md` — new "CTE inline comments" section

Resolves #46
