### PR TITLE
fix(generator): align = operators in WHERE clause conditions

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -186,6 +186,33 @@ HAVING COUNT(*) > 1
 
 ---
 
+### WHERE — `=` operator column alignment
+
+When a `WHERE` clause contains two or more equality (`=`) comparisons anywhere in the condition tree, the left-hand sides of all **top-level** `AND` equality conditions are right-padded so that the `=` signs align vertically. The target column is the longest LHS (across all `=` in the clause, including nested ones) plus two spaces.
+
+Parenthesised compound conditions (e.g. `(a = b OR c IS NULL)`) that appear as direct `AND` operands are kept on a single line.
+
+**Bad**
+```sql
+WHERE p.time_frame = _time_frame
+  AND e.participant_key = _participant_key
+  AND e.enabled
+  AND (
+    p.program_supplier_key = _program_supplier_key
+    OR _program_supplier_key IS NULL
+  )
+```
+
+**Good**
+```sql
+WHERE p.time_frame            = _time_frame
+  AND e.participant_key       = _participant_key
+  AND e.enabled
+  AND (p.program_supplier_key = _program_supplier_key OR _program_supplier_key IS NULL)
+```
+
+---
+
 ### `GROUP BY` — one expression per line
 
 Every `GROUP BY` expression is on its own line using the same leading-comma style as `SELECT`. `GROUP BY ALL` is exempt and stays on one line.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -6,7 +6,8 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - Bare JOIN → INNER JOIN normalization
 - AND/OR conditions always on separate lines in pretty mode
 - WHERE/HAVING/ON: first condition inline with keyword, AND/OR right-justified
-  so all condition content aligns at the same column
+  so all condition content aligns at the same column; = operators in WHERE
+  top-level AND conditions are column-aligned (padded to max LHS width + 2)
 - CTE: opening paren on its own line, comma-prefix separator
 - Consistent keyword casing; DuckDB functions in lowercase
 - IS NOT NULL preserved (not rewritten to NOT x IS NULL)
@@ -429,7 +430,65 @@ class JarifyGenerator(DuckDB.Generator):
     # ------------------------------------------------------------------
 
     def where_sql(self, expression: exp.Where) -> str:
-        return self._inline_clause_sql("WHERE", expression)
+        """Format WHERE with leading-AND style and = operator column-alignment.
+
+        When the top-level condition is a pure AND chain the = signs in simple
+        equality conditions are padded so they all align at the same column.
+        The target column is max(LHS width across all EQ in WHERE) + 2.
+
+        Parenthesised conditions that are direct AND operands (e.g. compound OR
+        filters) are rendered on a single line rather than expanded.
+
+        Falls back to _inline_clause_sql when the top-level is not AND (e.g.
+        a bare OR at the top level).
+        """
+        if not self.pretty or not isinstance(expression.this, exp.And):
+            return self._inline_clause_sql("WHERE", expression)
+
+        conditions = self._flatten_and(expression.this)
+
+        # Max EQ LHS width across entire WHERE tree (including nested EQs)
+        eq_lhs_widths = [len(self.sql(eq.this)) for eq in expression.find_all(exp.EQ)]
+        # Only align when there are at least 2 EQ comparisons total
+        target = (max(eq_lhs_widths) + 2) if len(eq_lhs_widths) >= 2 else 0
+
+        result: list[str] = []
+        for i, cond in enumerate(conditions):
+            if target > 0 and isinstance(cond, exp.EQ):
+                lhs = self.sql(cond.this)
+                rhs = self.sql(cond.expression)
+                cond_str = (
+                    f"{lhs.ljust(target)}= {rhs}" if "\n" not in lhs else self.sql(cond)
+                )
+            elif isinstance(cond, exp.Paren):
+                cond_str = self._compact_sql(cond)
+            else:
+                cond_str = self.sql(cond)
+
+            if i == 0:
+                result.append(f"WHERE {cond_str}")
+            else:
+                result.append(f"  AND {cond_str}")
+
+        return self.seg("\n".join(result))
+
+    def _flatten_and(self, condition: exp.Expression) -> list[exp.Expression]:
+        """Return the flat list of operands from a nested AND chain."""
+        if isinstance(condition, exp.And):
+            return self._flatten_and(condition.this) + self._flatten_and(
+                condition.expression
+            )
+        return [condition]
+
+    def _compact_sql(self, expression: exp.Expression) -> str:
+        """Render expression compactly without line breaks."""
+        saved = self.pretty
+        self.pretty = False
+        try:
+            result = self.sql(expression)
+        finally:
+            self.pretty = saved
+        return result
 
     def having_sql(self, expression: exp.Having) -> str:
         return self._inline_clause_sql("HAVING", expression)

--- a/tests/fixtures/duckdb/create_macro.expected.sql
+++ b/tests/fixtures/duckdb/create_macro.expected.sql
@@ -8,8 +8,8 @@ CREATE OR REPLACE MACRO get_programs_json
   SELECT
      json_object('programs', json_group_array(json_object('name', program_name, 'supplier', supplier_name)))
   FROM programs
-  WHERE participant_key = _participant_key
-    AND time_frame = _time_frame
-    AND supplier_key = _program_supplier_key
+  WHERE participant_key  = _participant_key
+    AND time_frame       = _time_frame
+    AND supplier_key     = _program_supplier_key
 )
 ;

--- a/tests/fixtures/select/where_eq_alignment.expected.sql
+++ b/tests/fixtures/select/where_eq_alignment.expected.sql
@@ -1,0 +1,9 @@
+SELECT
+   *
+FROM _programs          p
+INNER JOIN _enrollments e ON e.participant_key = p.participant_key
+WHERE p.time_frame            = _time_frame
+  AND e.participant_key       = _participant_key
+  AND e.enabled
+  AND (p.program_supplier_key = _program_supplier_key OR _program_supplier_key IS NULL)
+;

--- a/tests/fixtures/select/where_eq_alignment.input.sql
+++ b/tests/fixtures/select/where_eq_alignment.input.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM _programs p
+INNER JOIN _enrollments e ON e.participant_key = p.participant_key
+WHERE p.time_frame = _time_frame AND e.participant_key = _participant_key AND e.enabled AND (p.program_supplier_key = _program_supplier_key OR _program_supplier_key IS NULL);


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Aligns `=` operators in `WHERE` clause conditions so equality comparisons are easy to scan vertically.

## Root Cause

`where_sql` delegated to `_inline_clause_sql`, which only handles the leading-`AND` layout. It rendered each condition with natural spacing:

```sql
WHERE p.time_frame = _time_frame
  AND e.participant_key = _participant_key
  AND e.enabled
  AND (
    p.program_supplier_key = _program_supplier_key
    OR _program_supplier_key IS NULL
  )
```

## Fix

`where_sql` now works at the AST level when the top-level is a pure `AND` chain:

1. Flattens the `AND` chain with `_flatten_and`.
2. Collects all `EQ` nodes anywhere in the `WHERE` tree and computes `max LHS width + 2` as the alignment target.
3. Pads top-level equality LHS to the target column.
4. Renders top-level `Paren` conditions compactly (single line) via `_compact_sql`.

```sql
WHERE p.time_frame            = _time_frame
  AND e.participant_key       = _participant_key
  AND e.enabled
  AND (p.program_supplier_key = _program_supplier_key OR _program_supplier_key IS NULL)
```

Falls back to `_inline_clause_sql` when the top-level condition is not `AND` (e.g. a bare `OR`), preserving existing connector alignment behaviour.

## Changes

- `src/jarify/generator.py` — new `where_sql`, `_flatten_and`, `_compact_sql`
- `tests/fixtures/select/where_eq_alignment.{input,expected}.sql` — new fixture pair
- `tests/fixtures/duckdb/create_macro.expected.sql` — regenerated to reflect aligned three-EQ WHERE
- `docs/sql-style-guide.md` — new "WHERE — `=` operator column alignment" section

Resolves #48
