### PR TITLE
fix(generator): put IN subquery opening paren on its own line

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -213,6 +213,31 @@ WHERE p.time_frame            = _time_frame
 
 ---
 
+### WHERE — `IN (subquery)` layout
+
+An `IN` condition whose right-hand side is a subquery follows the same opening-paren style as CTEs: the `(` goes on its own line, the inner query is indented by one level, and `)` closes at the same column as `IN`.
+
+**Bad**
+```sql
+WHERE program_key IN (
+    SELECT
+       program_key
+    FROM _programs
+  )
+```
+
+**Good**
+```sql
+WHERE program_key IN
+(
+  SELECT
+     program_key
+  FROM _programs
+)
+```
+
+---
+
 ### `GROUP BY` — one expression per line
 
 Every `GROUP BY` expression is on its own line using the same leading-comma style as `SELECT`. `GROUP BY ALL` is exempt and stays on one line.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -525,12 +525,37 @@ class JarifyGenerator(DuckDB.Generator):
                 prefix = " " * max(0, keyword_width - len("OR "))
                 result.append(f"{prefix}{line}")
             else:
-                # Continuation lines inside parens: add one pad level so they
-                # stay more indented than the AND/OR line that opened them.
-                result.append(f"{' ' * self.pad}{line}")
+                # Pass continuation lines through as-is; child methods (e.g.
+                # in_sql) are responsible for their own relative indentation.
+                result.append(line)
             depth += line.count("(") - line.count(")")
 
         return self.seg("\n".join(result))
+
+    # ------------------------------------------------------------------
+    # IS NOT NULL: preserve original form instead of NOT x IS NULL
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # IN (subquery): opening paren on its own line
+    # ------------------------------------------------------------------
+
+    def in_sql(self, expression: exp.In) -> str:
+        """Render IN with a subquery as col IN\\n(\\n  SELECT ...\\n).
+
+        The opening paren is placed on its own line at the same indentation
+        level as the enclosing keyword (WHERE/HAVING), so the subquery block
+        mirrors the CTE body style used elsewhere.
+
+        Falls back to the base generator for IN with a value list.
+        """
+        query = expression.args.get("query")
+        if self.pretty and query is not None:
+            this = self.sql(expression, "this")
+            select_sql = self.sql(query.this)
+            indented = self.indent(select_sql)
+            return f"{this} IN\n(\n{indented}\n)"
+        return super().in_sql(expression)
 
     # ------------------------------------------------------------------
     # IS NOT NULL: preserve original form instead of NOT x IS NULL

--- a/tests/fixtures/cte/in_subquery.expected.sql
+++ b/tests/fixtures/cte/in_subquery.expected.sql
@@ -1,0 +1,16 @@
+WITH _programs AS
+(
+  FROM base_programs
+)
+,_offers AS
+(
+  FROM offers
+  WHERE program_key IN
+  (
+    SELECT
+       program_key
+    FROM _programs
+  )
+)
+FROM _offers
+;

--- a/tests/fixtures/cte/in_subquery.input.sql
+++ b/tests/fixtures/cte/in_subquery.input.sql
@@ -1,0 +1,3 @@
+WITH _programs AS (FROM base_programs),
+_offers AS (FROM offers WHERE program_key IN (SELECT program_key FROM _programs))
+SELECT * FROM _offers;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes `IN (subquery)` formatting so the opening paren follows the same own-line convention used for CTEs and macro bodies.

## Root Cause

Two issues combined to produce bad output:

1. No `in_sql` override — the base sqlglot generator put `(` on the same line as `IN`.
2. `_inline_clause_sql` added `self.pad` (2 spaces) to every continuation line that wasn't a top-level `AND`/`OR`, double-indenting the content that `in_sql` had already indented.

**Before:**
```sql
WHERE program_key IN (
    SELECT
       program_key
    FROM _programs
  )
```

## Fix

1. New `in_sql` override: when `In` has a `query` (subquery), renders as `{col} IN\n(\n{indented_select}\n)`. Falls back to base for value-list `IN`.

2. `_inline_clause_sql` else-branch: the extra `self.pad` prefix is removed. Child methods now own their relative indentation.

**After:**
```sql
WHERE program_key IN
(
  SELECT
     program_key
  FROM _programs
)
```

## Changes

- `src/jarify/generator.py` — new `in_sql` override; simplified `_inline_clause_sql` else-branch
- `tests/fixtures/cte/in_subquery.{input,expected}.sql` — new fixture pair
- `docs/sql-style-guide.md` — new "WHERE — `IN (subquery)` layout" section

Resolves #50
