### PR TITLE
feat(ci): publish jarify to PyPI via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write  # required for OIDC trusted publishing to PyPI
 
 jobs:
   publish:
@@ -42,6 +43,11 @@ jobs:
 
       - name: Build package
         run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish
+        env:
+          UV_PUBLISH_TRUSTED_PUBLISHING: true
 
       - name: Create GitHub Release
         run: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 John Allen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,37 +4,28 @@ Bespoke SQL linter and formatter for [DuckDB](https://duckdb.org), built on [sql
 
 Existing SQL formatters can't be configured to enforce a specific team style, and none of them are DuckDB-aware. Jarify parses SQL with the DuckDB dialect and rewrites it through an opinionated, non-configurable formatter — no style debates, consistent output everywhere.
 
-## Quick start
-
-No installation required. Run directly with [`uvx`](https://docs.astral.sh/uv/guides/tools/).
-
-### From a GitHub Release (recommended)
-
-Releases publish a pre-built wheel to the [Releases page](https://github.com/amfaro/jarify/releases). Pinning to a wheel is the fastest option because uv skips the build step:
+## Installation
 
 ```bash
-uvx --from "https://github.com/amfaro/jarify/releases/download/v0.0.1/jarify-0.0.1-py3-none-any.whl" jarify fmt path/to/query.sql
+uv tool install jarify
 ```
 
-### From git
-
-Always runs the latest commit on `main` — useful during development:
+Or run one-off without installing:
 
 ```bash
-uvx --from git+https://github.com/amfaro/jarify.git jarify fmt path/to/query.sql
+uvx jarify fmt path/to/query.sql
 ```
 
-Pin to a specific release tag:
+### Upgrade
 
 ```bash
-uvx --from "git+https://github.com/amfaro/jarify.git@v0.0.1" jarify fmt path/to/query.sql
+uv tool upgrade jarify
 ```
 
-### Persistent install
+### Pin to a specific version
 
 ```bash
-uv tool install "https://github.com/amfaro/jarify/releases/download/v0.0.1/jarify-0.0.1-py3-none-any.whl"
-jarify fmt path/to/query.sql
+uv tool install 'jarify==0.1.0'
 ```
 
 ## Commands
@@ -124,9 +115,9 @@ mise run check   # lint + test
 
 ### Releases
 
-Push a `v*` tag to trigger the publish workflow. GitHub Actions builds the wheel and sdist, attaches them to a GitHub Release, and generates release notes automatically.
+Push a `v*` tag to trigger the publish workflow. GitHub Actions builds the wheel and sdist, publishes to PyPI via OIDC trusted publishing, attaches artifacts to a GitHub Release, and generates release notes automatically.
 
 ```bash
-git tag v0.0.1
-git push origin v0.0.1
+git tag v0.1.0
+git push origin v0.1.0
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "jarify"
-version = "0.0.1"
+version = "0.1.0"
 description = "Bespoke SQL linter and formatter for DuckDB, powered by sqlglot"
 readme = "README.md"
 requires-python = ">=3.12"
+license = "MIT"
+keywords = ["sql", "duckdb", "formatter", "linter", "sqlglot"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Software Development :: Quality Assurance",
+]
 dependencies = [
     "click>=8.3.2",
     "rich>=14.3.3",


### PR DESCRIPTION
## Changes

- Add `id-token: write` permission to `publish.yml` for OIDC trusted publishing
- Add `uv publish` step after `uv build` (no stored credentials needed)
- Update README: `uv tool install jarify` is now canonical install path

## What requires manual action (see below)

Before merging and tagging, you need to set up the PyPI Trusted Publisher. See walkthrough in the PR description.

Closes #54