### PR TITLE
fix(cli): TTY-aware diff output and explicit NO_COLOR support

### DIFF
--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import difflib
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -16,7 +17,7 @@ from jarify.config import load_config
 from jarify.formatter import format_sql
 from jarify.linter import lint_sql
 
-console = Console(stderr=True)
+console = Console(stderr=True, no_color=bool(os.environ.get("NO_COLOR")))
 
 _STARTER_CONFIG = """\
 # jarify.toml — SQL linter & formatter configuration
@@ -269,4 +270,7 @@ def _print_diff(label: str, original: str, formatted: str) -> None:
     )
     if diff_lines:
         diff_text = "".join(diff_lines)
-        console.print(Syntax(diff_text, "diff", theme="monokai"))
+        if console.is_terminal and not console.no_color:
+            console.print(Syntax(diff_text, "diff", theme="monokai"))
+        else:
+            click.echo(diff_text, err=True)


### PR DESCRIPTION
## Changes

Two fixes for CI / non-interactive contexts:

**1. `--diff` trailing whitespace**
Rich's `Syntax` renderer pads every diff line to terminal width (80 chars) even when stderr is piped. Fixed by falling back to plain `click.echo` when not a TTY or `NO_COLOR` is set.

Before:
```
--- a/<stdin>                                                                   
+++ b/<stdin>                                                                   
```
After:
```
--- a/<stdin>
+++ b/<stdin>
```

**2. Explicit `NO_COLOR` support**
`Console` now reads `NO_COLOR` env var at construction time, making it explicit rather than relying on Rich's internal detection path.

Resolves #56