### PR TITLE
Editor integration guides (Neovim + VS Code)

### DIFF
--- a/docs/editors/README.md
+++ b/docs/editors/README.md
@@ -1,0 +1,16 @@
+# Editor Clients
+
+Jarify ships a stable CLI that any editor can drive.
+
+| Editor | Details |
+|--------|---------|
+| Neovim | [neovim.md](neovim.md) |
+| VS Code | [`amfaro/jarify-vscode`](https://github.com/amfaro/jarify-vscode) |
+
+## Prerequisites
+
+Install jarify as a `uv` tool so the `jarify` binary is on your `PATH`:
+
+```bash
+uv tool install jarify
+```

--- a/docs/editors/neovim.md
+++ b/docs/editors/neovim.md
@@ -1,0 +1,63 @@
+# Neovim
+
+Formatting via [`conform.nvim`](https://github.com/stevearc/conform.nvim) and diagnostics via [`nvim-lint`](https://github.com/mfussenegger/nvim-lint).
+
+## Prerequisites
+
+- `jarify` on your `PATH` — see [Editor Clients](README.md#prerequisites)
+- `conform.nvim` and `nvim-lint` installed
+
+## conform.nvim — format on save
+
+```lua
+require("conform").setup({
+  formatters_by_ft = {
+    sql = { "jarify" },
+  },
+  formatters = {
+    jarify = {
+      command = "jarify",
+      args = { "fmt", "--stdin-filename", "$FILENAME", "-" },
+      stdin = true,
+    },
+  },
+  format_on_save = {
+    timeout_ms = 2000,
+    lsp_fallback = false,
+  },
+})
+```
+
+## nvim-lint — inline diagnostics
+
+```lua
+local lint = require("lint")
+
+lint.linters.jarify = {
+  cmd = "jarify",
+  stdin = true,
+  args = { "lint", "--format", "json", "--stdin-filename", function() return vim.fn.expand("%") end, "-" },
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = function(output)
+    local diagnostics = {}
+    for _, v in ipairs(output ~= "" and vim.json.decode(output) or {}) do
+      table.insert(diagnostics, {
+        lnum     = (v.line or 1) - 1,
+        col      = (v.column or 1) - 1,
+        message  = ("[%s] %s"):format(v.rule, v.message),
+        severity = v.severity == "error" and vim.diagnostic.severity.ERROR or vim.diagnostic.severity.WARN,
+        source   = "jarify",
+      })
+    end
+    return diagnostics
+  end,
+}
+
+lint.linters_by_ft = { sql = { "jarify" } }
+
+vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave" }, {
+  callback = function() lint.try_lint() end,
+})
+```
+

--- a/docs/editors/neovim.md
+++ b/docs/editors/neovim.md
@@ -22,8 +22,8 @@ require("conform").setup({
     },
   },
   format_on_save = {
-    timeout_ms = 2000,
-    lsp_fallback = false,
+    timeout_ms = 500,
+    lsp_format = "fallback",
   },
 })
 ```
@@ -33,31 +33,54 @@ require("conform").setup({
 ```lua
 local lint = require("lint")
 
+local severity_map = {
+  error = vim.diagnostic.severity.ERROR,
+  warn  = vim.diagnostic.severity.WARN,
+}
+
 lint.linters.jarify = {
   cmd = "jarify",
   stdin = true,
-  args = { "lint", "--format", "json", "--stdin-filename", function() return vim.fn.expand("%") end, "-" },
-  stream = "stdout",
+  args = {
+    "lint", "--format", "json",
+    "--stdin-filename", function() return vim.api.nvim_buf_get_name(0) end,
+    "-",
+  },
   ignore_exitcode = true,
-  parser = function(output)
+  parser = function(output, bufnr)
+    if output == nil or vim.trim(output) == "" then return {} end
+
+    local ok, decoded = pcall(vim.json.decode, output)
+    if not ok then return {} end
+
+    local filename = vim.fs.normalize(vim.api.nvim_buf_get_name(bufnr))
     local diagnostics = {}
-    for _, v in ipairs(output ~= "" and vim.json.decode(output) or {}) do
-      table.insert(diagnostics, {
-        lnum     = (v.line or 1) - 1,
-        col      = (v.column or 1) - 1,
-        message  = ("[%s] %s"):format(v.rule, v.message),
-        severity = v.severity == "error" and vim.diagnostic.severity.ERROR or vim.diagnostic.severity.WARN,
-        source   = "jarify",
-      })
+
+    for _, item in ipairs(decoded or {}) do
+      local item_file = item.filename and vim.fs.normalize(item.filename) or filename
+      if item_file == filename then
+        local lnum = math.max((item.line or 1) - 1, 0)
+        local col  = math.max((item.column or 1) - 1, 0)
+        table.insert(diagnostics, {
+          lnum     = lnum,
+          col      = col,
+          end_lnum = lnum,
+          end_col  = col,
+          message  = string.format("[%s] %s", item.rule or "jarify", item.message),
+          code     = item.rule,
+          source   = "jarify",
+          severity = severity_map[item.severity] or vim.diagnostic.severity.WARN,
+        })
+      end
     end
+
     return diagnostics
   end,
 }
 
 lint.linters_by_ft = { sql = { "jarify" } }
 
-vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave" }, {
-  callback = function() lint.try_lint() end,
+vim.api.nvim_create_autocmd({ "BufReadPost", "BufEnter", "InsertLeave", "BufWritePost" }, {
+  callback = function() vim.schedule(lint.try_lint) end,
 })
 ```
-


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Adds `docs/editors/` with a client index and Neovim setup guide.

- `docs/editors/README.md` — index table of supported editor clients with install prerequisites
- `docs/editors/neovim.md` — `conform.nvim` formatter + `nvim-lint` diagnostics, synced to the actual working config in use

### Neovim guide reflects the live setup

The `neovim.md` snippet was updated to match the real configuration:

- `format_on_save`: `timeout_ms = 500`, `lsp_format = "fallback"` (was 2000 / `lsp_fallback`)
- `nvim-lint` linter uses `vim.api.nvim_buf_get_name(0)` for `--stdin-filename`
- `pcall` wraps JSON decode to handle empty/invalid output gracefully
- Diagnostics filtered by normalized filename to avoid false positives from multi-file output
- Diagnostic items include `end_lnum`, `end_col`, and `code` fields
- `severity_map` table replaces inline ternary
- Autocmd includes `BufEnter` and wraps `lint.try_lint` in `vim.schedule`

Resolves #59
