### PR TITLE
fix: lint violations now report accurate line and column positions

### DIFF
--- a/src/jarify/rules/base.py
+++ b/src/jarify/rules/base.py
@@ -11,6 +11,26 @@ if TYPE_CHECKING:
     from jarify.types import LintViolation
 
 
+def _node_pos(node: Expression) -> tuple[int | None, int | None]:
+    """Return (line, col) for a sqlglot node.
+
+    sqlglot stores position in ``node.meta`` for leaf-level nodes (Identifiers,
+    Literals, etc.). Higher-level nodes (CTE, Join, Select, …) often have an
+    empty ``meta``, so we fall back to the first descendant that carries a
+    position.
+    """
+    line = node.meta.get("line")
+    col = node.meta.get("col")
+    if line is not None:
+        return line, col
+    for child in node.walk():
+        line = child.meta.get("line")
+        col = child.meta.get("col")
+        if line is not None:
+            return line, col
+    return None, None
+
+
 class FormatterRule(ABC):
     """A rule that can both check (lint) and transform (format) a SQL AST."""
 

--- a/src/jarify/rules/consistent_empty_array.py
+++ b/src/jarify/rules/consistent_empty_array.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlglot.expressions as exp
 from sqlglot.expressions import DataType
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -35,6 +35,7 @@ class ConsistentEmptyArrayRule(FormatterRule):
 
             # Pattern 1: '[]'::type[] — literal directly cast to array
             if isinstance(cast.this, exp.Literal) and cast.this.is_string and cast.this.name == "[]":
+                _line, _col = _node_pos(cast.this)
                 violations.append(
                     LintViolation(
                         rule=self.name,
@@ -43,6 +44,8 @@ class ConsistentEmptyArrayRule(FormatterRule):
                             f"Use the native empty array literal [] instead of '[]'::{canonical};"
                             " cast the COALESCE result to the target type when needed"
                         ),
+                        line=_line,
+                        column=_col,
                     )
                 )
 
@@ -50,6 +53,7 @@ class ConsistentEmptyArrayRule(FormatterRule):
             elif isinstance(cast.this, exp.Coalesce):
                 for arg in cast.this.expressions:
                     if isinstance(arg, exp.Literal) and arg.is_string and arg.name == "[]":
+                        _line, _col = _node_pos(arg)
                         violations.append(
                             LintViolation(
                                 rule=self.name,
@@ -58,6 +62,8 @@ class ConsistentEmptyArrayRule(FormatterRule):
                                     f"Use [] instead of '[]' as the COALESCE fallback in COALESCE(...)::{ canonical};"
                                     " prefer native empty array literal"
                                 ),
+                                line=_line,
+                                column=_col,
                             )
                         )
                         break

--- a/src/jarify/rules/cte_naming.py
+++ b/src/jarify/rules/cte_naming.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -56,11 +56,14 @@ class CteNamingRule(FormatterRule):
             return []
         for cte in with_clause.expressions:
             if cte.alias and not cte.alias.startswith("_"):
+                _line, _col = _node_pos(cte)
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         severity=self.severity,
                         message=f"CTE '{cte.alias}' should start with an underscore (e.g. '_{cte.alias}')",
+                        line=_line,
+                        column=_col,
                     )
                 )
         return violations

--- a/src/jarify/rules/duckdb_prefer_qualify.py
+++ b/src/jarify/rules/duckdb_prefer_qualify.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -50,11 +50,14 @@ class DuckdbPreferQualifyRule(FormatterRule):
             # Does the inner query have window functions?
             has_window = any(True for _ in inner.find_all(exp.Window))
             if has_window:
+                _line, _col = _node_pos(select)
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         severity=self.severity,
                         message=("Consider using QUALIFY instead of a subquery to filter window function results"),
+                        line=_line,
+                        column=_col,
                     )
                 )
         return violations

--- a/src/jarify/rules/duckdb_type_style.py
+++ b/src/jarify/rules/duckdb_type_style.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlglot.expressions as exp
 from sqlglot.expressions import DataType
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 # DType variants that survive DuckDB parsing and are non-canonical.
@@ -47,11 +47,14 @@ class DuckdbTypeStyleRule(FormatterRule):
             canonical = _NON_CANONICAL.get(dtype.this)
             if canonical:
                 raw = dtype.this.name
+                _line, _col = _node_pos(dtype)
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         severity=self.severity,
                         message=f"Prefer '{canonical}' over '{raw}' in DuckDB",
+                        line=_line,
+                        column=_col,
                     )
                 )
         return violations

--- a/src/jarify/rules/no_implicit_cross_join.py
+++ b/src/jarify/rules/no_implicit_cross_join.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -34,11 +34,14 @@ class NoImplicitCrossJoinRule(FormatterRule):
                 and not join.args.get("using")
                 and not join.args.get("method")
             ):
+                _line, _col = _node_pos(join)
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         severity=self.severity,
                         message=("Implicit CROSS JOIN detected; use explicit CROSS JOIN or add an ON/USING clause"),
+                        line=_line,
+                        column=_col,
                     )
                 )
         return violations

--- a/src/jarify/rules/no_select_star.py
+++ b/src/jarify/rules/no_select_star.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -31,13 +31,14 @@ class NoSelectStarRule(FormatterRule):
             if isinstance(parent, exp.Select) or (
                 isinstance(parent, exp.Column) and isinstance(parent.parent, exp.Select)
             ):
+                _line, _col = _node_pos(star)
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         message="Avoid SELECT *; list columns explicitly",
                         severity=self.severity,
-                        line=getattr(star, "line", None),
-                        column=getattr(star, "col", None),
+                        line=_line,
+                        column=_col,
                     )
                 )
         return violations

--- a/src/jarify/rules/no_select_star_in_cte.py
+++ b/src/jarify/rules/no_select_star_in_cte.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -37,11 +37,14 @@ class NoSelectStarInCteRule(FormatterRule):
                 if isinstance(parent, exp.Select) or (
                     isinstance(parent, exp.Column) and isinstance(parent.parent, exp.Select)
                 ):
+                    _line, _col = _node_pos(star)
                     violations.append(
                         LintViolation(
                             rule=self.name,
                             severity=self.severity,
                             message=f"Avoid SELECT * inside CTE '{cte_name}'; list columns explicitly",
+                            line=_line,
+                            column=_col,
                         )
                     )
 

--- a/src/jarify/rules/no_unused_cte.py
+++ b/src/jarify/rules/no_unused_cte.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -30,7 +30,8 @@ class NoUnusedCteRule(FormatterRule):
         if not with_clause:
             return []
 
-        cte_names = {cte.alias.lower() for cte in with_clause.expressions if cte.alias}
+        cte_nodes = {cte.alias.lower(): cte for cte in with_clause.expressions if cte.alias}
+        cte_names = set(cte_nodes)
 
         # Collect all table references in the query body (excluding the CTE definitions themselves)
         referenced: set[str] = set()
@@ -46,11 +47,14 @@ class NoUnusedCteRule(FormatterRule):
 
         for name in cte_names:
             if name not in referenced:
+                _line, _col = _node_pos(cte_nodes[name])
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         severity=self.severity,
                         message=f"CTE '{name}' is defined but never referenced",
+                        line=_line,
+                        column=_col,
                     )
                 )
         return violations

--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -48,11 +48,14 @@ class PreferGroupByAllRule(FormatterRule):
             non_agg_set = set(non_agg_sqls)
 
             if non_agg_set and non_agg_set == group_sqls:
+                _line, _col = _node_pos(group)
                 violations.append(
                     LintViolation(
                         rule=self.name,
                         severity=self.severity,
                         message="All non-aggregated SELECT columns are listed in GROUP BY; prefer GROUP BY ALL",
+                        line=_line,
+                        column=_col,
                     )
                 )
 

--- a/src/jarify/rules/prefer_using_over_on.py
+++ b/src/jarify/rules/prefer_using_over_on.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
@@ -49,6 +49,7 @@ class PreferUsingOverOnRule(FormatterRule):
 
             if rewritable:
                 cols = ", ".join(rewritable)
+                _line, _col = _node_pos(join)
                 violations.append(
                     LintViolation(
                         rule=self.name,
@@ -57,6 +58,8 @@ class PreferUsingOverOnRule(FormatterRule):
                             f"ON clause can be simplified to USING ({cols})"
                             " — both sides reference the same column name"
                         ),
+                        line=_line,
+                        column=_col,
                     )
                 )
 

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -206,3 +206,32 @@ class TestNoSelectStarInCte:
         rules = _lint(sql)
         assert "no-select-star-in-cte" not in rules
 
+
+class TestViolationPositions:
+    """Verify that violations report line/column from node.meta, not None."""
+
+    def _violations(self, sql: str, **overrides):
+        config = JarifyConfig(**overrides)
+        return lint_sql(sql, config)
+
+    def test_no_select_star_has_position(self):
+        violations = self._violations("SELECT * FROM t")
+        v = next(v for v in violations if v.rule == "no-select-star")
+        assert v.line is not None, "line should not be None"
+        assert v.column is not None, "column should not be None"
+
+    def test_no_unused_cte_has_position(self):
+        violations = self._violations("WITH unused AS (SELECT 1 AS x) SELECT 2")
+        v = next(v for v in violations if v.rule == "no-unused-cte")
+        assert v.line is not None, "line should not be None"
+
+    def test_cte_naming_has_position(self):
+        violations = self._violations("WITH people AS (SELECT 1 AS id) SELECT id FROM people")
+        v = next(v for v in violations if v.rule == "cte-naming")
+        assert v.line is not None, "line should not be None"
+
+    def test_prefer_using_over_on_has_position(self):
+        violations = self._violations("SELECT a.x FROM a INNER JOIN b ON a.id = b.id")
+        v = next(v for v in violations if v.rule == "prefer-using-over-on")
+        assert v.line is not None, "line should not be None"
+


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

All lint violations were reporting `line=None` / `column=None` because rules were reading node position incorrectly. sqlglot stores position in `node.meta`, not as direct node attributes.

**Root cause:** `no_select_star` used `getattr(node, "line", None)` (wrong attribute path); all other rules omitted position entirely.

**Fix:**

- Add `_node_pos(node)` helper to `rules/base.py` — reads `node.meta.get("line")` / `node.meta.get("col")`, then falls back to the first descendant with a populated `meta` when the node itself carries no position info (CTE, Join, and Select nodes store position on their child `Identifier` nodes)
- Apply `_node_pos()` in every rule `check()` method across all 9 affected rules
- Add `TestViolationPositions` class with 4 regression tests confirming `line is not None`

Resolves #65
