### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Install dependencies
         run: uv sync --frozen --all-groups

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,17 +28,17 @@ jobs:
 
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_ID }}
           private-key: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Install dependencies
         run: uv sync --frozen


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Bumps three GitHub Actions that were running on the deprecated Node.js 20 runtime to their latest Node.js 24-compatible versions.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v6` |
| `actions/create-github-app-token` | `v2` | `v3` |
| `jdx/mise-action` | `v2` | `v4` |

`dopplerhq/secrets-fetch-action@v2.0.0` was already at the latest version and is unchanged.

Both `ci.yml` and `publish.yml` updated.

Resolves #69
