### PR TITLE
Fix config discovery to anchor from stdin-filename, not cwd

### DIFF
--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -68,7 +68,8 @@ def fmt(
 
     Pass - as a file argument to read from stdin.
     """
-    config = load_config(config_path)
+    config_start = Path(stdin_filename).parent if stdin_filename != "<stdin>" else None
+    config = load_config(config_path, start=config_start)
     any_changed = False
 
     inputs = _resolve_inputs(files, stdin_filename)
@@ -131,7 +132,8 @@ def lint(
     Exit code: 0 = clean, 1 = violations found, 2 = error.
     Pass - as a file argument to read from stdin.
     """
-    config = load_config(config_path)
+    config_start = Path(stdin_filename).parent if stdin_filename != "<stdin>" else None
+    config = load_config(config_path, start=config_start)
     total_violations = 0
     has_errors = False
     all_results: list[tuple[str, list]] = []

--- a/src/jarify/config.py
+++ b/src/jarify/config.py
@@ -74,9 +74,15 @@ def find_config(start: Path | None = None) -> Path | None:
     return None
 
 
-def load_config(path: Path | None = None) -> JarifyConfig:
-    """Load config from a file path, or discover one automatically."""
-    config_path = path or find_config()
+def load_config(path: Path | None = None, start: Path | None = None) -> JarifyConfig:
+    """Load config from a file path, or discover one automatically.
+
+    *start* seeds the upward search when no explicit *path* is given.
+    Pass the parent directory of the file being processed (e.g. from
+    ``--stdin-filename``) so config discovery anchors to that file rather
+    than ``cwd``.
+    """
+    config_path = path or find_config(start)
     if config_path is None:
         return JarifyConfig()
     with config_path.open("rb") as f:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,10 @@
 """Tests for config loading."""
 
-from jarify.config import JarifyConfig
+from pathlib import Path
+
+import pytest
+
+from jarify.config import JarifyConfig, find_config, load_config
 
 
 def test_default_config():
@@ -16,3 +20,60 @@ def test_config_from_dict():
     config = JarifyConfig.from_dict({"indent": 4, "uppercase_keywords": False})
     assert config.indent == 4
     assert config.uppercase_keywords is False
+
+
+def test_find_config_walks_up(tmp_path: Path) -> None:
+    # Place jarify.toml two levels above where we start the search.
+    config_file = tmp_path / "jarify.toml"
+    config_file.write_text("[jarify]\nindent = 4\n")
+    deep = tmp_path / "a" / "b"
+    deep.mkdir(parents=True)
+
+    found = find_config(start=deep)
+    assert found == config_file
+
+
+def test_find_config_returns_none_when_missing(tmp_path: Path) -> None:
+    assert find_config(start=tmp_path) is None
+
+
+def test_load_config_uses_start(tmp_path: Path) -> None:
+    config_file = tmp_path / "jarify.toml"
+    config_file.write_text("[jarify]\nindent = 8\n")
+    deep = tmp_path / "sub"
+    deep.mkdir()
+
+    config = load_config(start=deep)
+    assert config.indent == 8
+
+
+def test_load_config_explicit_path_takes_precedence(tmp_path: Path) -> None:
+    # Even with a start that would find a different config, explicit path wins.
+    explicit = tmp_path / "explicit.toml"
+    explicit.write_text("[jarify]\nindent = 3\n")
+    other = tmp_path / "other" / "jarify.toml"
+    other.parent.mkdir()
+    other.write_text("[jarify]\nindent = 99\n")
+
+    config = load_config(path=explicit, start=other.parent)
+    assert config.indent == 3
+
+
+@pytest.mark.parametrize("command", ["fmt", "lint"])
+def test_stdin_filename_anchors_config(tmp_path: Path, command: str) -> None:
+    """--stdin-filename parent dir is used to discover jarify.toml."""
+    from click.testing import CliRunner
+
+    from jarify.cli import main
+
+    config_file = tmp_path / "jarify.toml"
+    config_file.write_text("[jarify]\nindent = 6\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [command, "--stdin-filename", str(tmp_path / "query.sql"), "-"],
+        input="SELECT 1",
+        catch_exceptions=False,
+    )
+    assert result.exit_code in (0, 1), result.output


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Problem

When reading from stdin, `find_config()` seeded its upward walk from `Path.cwd()`. Editors (neovim, Helix, etc.) call `jarify fmt --stdin-filename /path/to/query.sql -` from an arbitrary working directory, so the wrong `jarify.toml` could be found — or none at all.

## Fix

`load_config()` now accepts a `start` parameter that is forwarded to `find_config()`. Both `fmt` and `lint` derive the anchor directory from `--stdin-filename` when it is not the default `<stdin>` sentinel, and pass it as `start`. This matches the behaviour of ruff, biome, and other tools — editors need zero `cwd` manipulation.

### Changed files

- `src/jarify/config.py`: `load_config(path, start=None)` — new `start` kwarg forwarded to `find_config()`
- `src/jarify/cli.py`: both `fmt` and `lint` extract `Path(stdin_filename).parent` when a real filename is provided
- `tests/test_config.py`: tests for `find_config(start=...)`, `load_config(start=...)`, explicit-path precedence, and parametrized CLI tests for both `fmt` and `lint`

Resolves #71
