### PR TITLE
fix(rules): suppress no-select-star for FROM-first candidates when prefer_from_first is enabled

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -706,7 +706,9 @@ Lint rules report violations but do not modify the SQL. All rules default to `wa
 
 Flag `SELECT *`. `COUNT(*)` is exempt.
 
-**Bad**
+When `prefer_from_first = true` (the default), single-table `SELECT *` queries are not flagged because the formatter already rewrites them to FROM-first syntax (`FROM t`). The rule still fires for `SELECT *` with JOINs, since those are not rewritten.
+
+**Bad** (with `prefer_from_first = false`)
 ```sql
 SELECT * FROM products
 ```
@@ -717,6 +719,12 @@ SELECT
    id
   ,name
   ,price
+FROM products
+;
+```
+
+**Also good** (formatter rewrites `SELECT * FROM products` to this when `prefer_from_first = true`)
+```sql
 FROM products
 ;
 ```

--- a/src/jarify/rules/__init__.py
+++ b/src/jarify/rules/__init__.py
@@ -37,7 +37,7 @@ def get_default_rules(config: JarifyConfig) -> list[FormatterRule]:
 
     # --- General lint rules (checkers, no AST mutation) ---
     if config.no_select_star != "off":
-        rules.append(NoSelectStarRule(severity=config.no_select_star))
+        rules.append(NoSelectStarRule(severity=config.no_select_star, prefer_from_first=config.prefer_from_first))
     if config.no_implicit_cross_join != "off":
         rules.append(NoImplicitCrossJoinRule(severity=config.no_implicit_cross_join))
     if config.no_unused_cte != "off":

--- a/src/jarify/rules/no_select_star.py
+++ b/src/jarify/rules/no_select_star.py
@@ -11,8 +11,9 @@ from jarify.types import LintViolation
 class NoSelectStarRule(FormatterRule):
     """Flag SELECT * (or table.*) as a lint violation."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", prefer_from_first: bool = False) -> None:
         self.severity = severity
+        self.prefer_from_first = prefer_from_first
 
     @property
     def name(self) -> str:
@@ -31,6 +32,19 @@ class NoSelectStarRule(FormatterRule):
             if isinstance(parent, exp.Select) or (
                 isinstance(parent, exp.Column) and isinstance(parent.parent, exp.Select)
             ):
+                select = parent if isinstance(parent, exp.Select) else parent.parent
+                # When prefer_from_first is on, SELECT * FROM t gets rewritten to
+                # FROM t by the formatter. Linting the formatted output (FROM t)
+                # would re-parse to the same AST, so skip single-table star selects
+                # that the formatter already handles via FROM-first syntax.
+                if (
+                    self.prefer_from_first
+                    and len(select.expressions) == 1
+                    and isinstance(select.expressions[0], exp.Star)
+                    and not select.args.get("distinct")
+                    and not select.args.get("joins")
+                ):
+                    continue
                 _line, _col = _node_pos(star)
                 violations.append(
                     LintViolation(

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -14,7 +14,8 @@ def _lint(sql: str, **config_overrides) -> list[str]:
 
 class TestNoSelectStar:
     def test_warns_on_select_star(self):
-        rules = _lint("SELECT * FROM t")
+        # prefer_from_first=False: formatter won't rewrite, so lint should warn
+        rules = _lint("SELECT * FROM t", prefer_from_first=False)
         assert "no-select-star" in rules
 
     def test_no_warn_on_explicit_columns(self):
@@ -22,12 +23,35 @@ class TestNoSelectStar:
         assert "no-select-star" not in rules
 
     def test_off_disables_rule(self):
-        rules = _lint("SELECT * FROM t", no_select_star="off")
+        rules = _lint("SELECT * FROM t", no_select_star="off", prefer_from_first=False)
         assert "no-select-star" not in rules
 
     def test_count_star_not_flagged(self):
         rules = _lint("SELECT COUNT(*) FROM t")
         assert "no-select-star" not in rules
+
+    def test_no_warn_on_from_first_when_prefer_from_first_enabled(self):
+        # fmt rewrites SELECT * FROM t → FROM t when prefer_from_first=True.
+        # Linting the formatted output must not re-fire no-select-star.
+        rules = _lint("FROM t", prefer_from_first=True)
+        assert "no-select-star" not in rules
+
+    def test_no_warn_on_select_star_when_prefer_from_first_enabled(self):
+        # SELECT * FROM single-table is what the formatter handles via FROM-first.
+        # Both SELECT * FROM t and FROM t parse to the same AST, so linting
+        # SELECT * FROM t should also not warn when prefer_from_first=True.
+        rules = _lint("SELECT * FROM t", prefer_from_first=True)
+        assert "no-select-star" not in rules
+
+    def test_warns_on_select_star_with_joins_even_when_prefer_from_first_enabled(self):
+        # SELECT * with joins is not a FROM-first candidate; still flag it.
+        rules = _lint("SELECT * FROM t JOIN u ON t.id = u.id", prefer_from_first=True)
+        assert "no-select-star" in rules
+
+    def test_warns_when_prefer_from_first_disabled(self):
+        # FROM t parses as SELECT * FROM t; should fire when prefer_from_first=False.
+        rules = _lint("FROM t", prefer_from_first=False)
+        assert "no-select-star" in rules
 
 
 class TestNoUnusedCte:
@@ -56,7 +80,7 @@ class TestLintSeverity:
         from jarify.config import JarifyConfig
         from jarify.linter import lint_sql
 
-        config = JarifyConfig(no_select_star="error")
+        config = JarifyConfig(no_select_star="error", prefer_from_first=False)
         violations = lint_sql("SELECT * FROM t", config)
         star_violations = [v for v in violations if v.rule == "no-select-star"]
         assert star_violations
@@ -66,7 +90,7 @@ class TestLintSeverity:
         from jarify.config import JarifyConfig
         from jarify.linter import lint_sql
 
-        config = JarifyConfig(no_select_star="warn")
+        config = JarifyConfig(no_select_star="warn", prefer_from_first=False)
         violations = lint_sql("SELECT * FROM t", config)
         star_violations = [v for v in violations if v.rule == "no-select-star"]
         assert star_violations
@@ -215,7 +239,7 @@ class TestViolationPositions:
         return lint_sql(sql, config)
 
     def test_no_select_star_has_position(self):
-        violations = self._violations("SELECT * FROM t")
+        violations = self._violations("SELECT * FROM t", prefer_from_first=False)
         v = next(v for v in violations if v.rule == "no-select-star")
         assert v.line is not None, "line should not be None"
         assert v.column is not None, "column should not be None"


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes the contradiction between `jarify fmt` and `jarify lint` when `prefer_from_first = true`.

**Root cause:** sqlglot parses both `SELECT * FROM t` and `FROM t` into the same AST — `Select(expressions=[Star()], from_=From(...))`. So linting the formatter's `FROM t` output always re-fired `no-select-star`.

**Fix:** Pass `prefer_from_first` config to `NoSelectStarRule`. When enabled, skip the violation for single-table star selects (no JOINs, no DISTINCT) — exactly the pattern the formatter already rewrites to FROM-first syntax. `SELECT *` with JOINs still fires since the formatter does not rewrite those.

## Changes

| File | What |
|------|------|
| `src/jarify/rules/no_select_star.py` | Accept `prefer_from_first` param; skip FROM-first candidates in `check()` |
| `src/jarify/rules/__init__.py` | Pass `prefer_from_first=config.prefer_from_first` when registering the rule |
| `tests/test_lint_rules.py` | Add 4 new tests; update 5 existing tests that need the rule to fire with `prefer_from_first=False` |
| `docs/sql-style-guide.md` | Document the `prefer_from_first` interaction for `no-select-star` |

## Verification

`mise run check` passes — 128 tests, lint clean.

Resolves #73
