### PR TITLE
fix(ci): use --bumped-version flag in release prepare script

### DIFF
--- a/.mise/tasks/release/prepare
+++ b/.mise/tasks/release/prepare
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # git-cliff computes the next version from conventional commits -- no manual parsing needed
-new_version=$(git-cliff --bump --next-version --stdout 2>/dev/null || true)
+new_version=$(git-cliff --bumped-version 2>/dev/null || true)
 new_version="${new_version#v}"  # strip leading 'v' if present
 
 if [[ -z "$new_version" ]]; then


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes the `prepare-release` workflow that always exited early with "No releasable commits. Skipping." even when releasable conventional commits existed.

**Root cause:** `.mise/tasks/release/prepare` called `git-cliff --bump --next-version --stdout`, but `--next-version` is not a valid flag in git-cliff 2.x. The error was silenced by `2>/dev/null`, `|| true` forced exit 0, and the version variable was always empty.

**Fix:** Replace with `--bumped-version`, the correct git-cliff 2.x flag.

**Verified locally:**

- `git-cliff --bump --next-version --stdout 2>/dev/null || echo EMPTY` outputs `EMPTY`
- `git-cliff --bumped-version` outputs `v0.1.2`

With the fix, the next run will correctly detect the unreleased fix from #76 and open a release PR for v0.1.2.

Resolves #77
