### PR TITLE
refactor(rules): add LintOnlyRule base class to eliminate apply() no-op

### DIFF
--- a/src/jarify/rules/base.py
+++ b/src/jarify/rules/base.py
@@ -46,3 +46,10 @@ class FormatterRule(ABC):
     def check(self, tree: Expression) -> list[LintViolation]:
         """Return violations found in the tree. Default: no violations."""
         return []
+
+
+class LintOnlyRule(FormatterRule):
+    """Base class for rules that only check (lint) and never transform the AST."""
+
+    def apply(self, tree: Expression) -> Expression:
+        return tree

--- a/src/jarify/rules/duckdb_prefer_qualify.py
+++ b/src/jarify/rules/duckdb_prefer_qualify.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class DuckdbPreferQualifyRule(FormatterRule):
+class DuckdbPreferQualifyRule(LintOnlyRule):
     """Lint: suggest QUALIFY instead of filtering on a window function in a subquery."""
 
     def __init__(self, severity: str = "warn") -> None:
@@ -24,9 +24,6 @@ class DuckdbPreferQualifyRule(FormatterRule):
     @property
     def name(self) -> str:
         return "duckdb-prefer-qualify"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/duckdb_type_style.py
+++ b/src/jarify/rules/duckdb_type_style.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlglot.expressions as exp
 from sqlglot.expressions import DataType
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 # DType variants that survive DuckDB parsing and are non-canonical.
@@ -17,7 +17,7 @@ _NON_CANONICAL: dict[DataType.Type, str] = {
 }
 
 
-class DuckdbTypeStyleRule(FormatterRule):
+class DuckdbTypeStyleRule(LintOnlyRule):
     """Lint: warn when non-canonical DuckDB type names are used.
 
     Detectable non-canonical types after DuckDB parsing:
@@ -35,9 +35,6 @@ class DuckdbTypeStyleRule(FormatterRule):
     @property
     def name(self) -> str:
         return "duckdb-type-style"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/no_implicit_cross_join.py
+++ b/src/jarify/rules/no_implicit_cross_join.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class NoImplicitCrossJoinRule(FormatterRule):
+class NoImplicitCrossJoinRule(LintOnlyRule):
     """Flag comma-separated tables in FROM (implicit CROSS JOIN)."""
 
     def __init__(self, severity: str = "warn") -> None:
@@ -17,9 +17,6 @@ class NoImplicitCrossJoinRule(FormatterRule):
     @property
     def name(self) -> str:
         return "no-implicit-cross-join"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/no_select_star.py
+++ b/src/jarify/rules/no_select_star.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class NoSelectStarRule(FormatterRule):
+class NoSelectStarRule(LintOnlyRule):
     """Flag SELECT * (or table.*) as a lint violation."""
 
     def __init__(self, severity: str = "warn", prefer_from_first: bool = False) -> None:
@@ -18,9 +18,6 @@ class NoSelectStarRule(FormatterRule):
     @property
     def name(self) -> str:
         return "no-select-star"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/no_select_star_in_cte.py
+++ b/src/jarify/rules/no_select_star_in_cte.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class NoSelectStarInCteRule(FormatterRule):
+class NoSelectStarInCteRule(LintOnlyRule):
     """Lint: flag SELECT * used inside a CTE body (stricter than no-select-star)."""
 
     def __init__(self, severity: str = "warn") -> None:
@@ -17,9 +17,6 @@ class NoSelectStarInCteRule(FormatterRule):
     @property
     def name(self) -> str:
         return "no-select-star-in-cte"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/no_unused_cte.py
+++ b/src/jarify/rules/no_unused_cte.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class NoUnusedCteRule(FormatterRule):
+class NoUnusedCteRule(LintOnlyRule):
     """Flag CTEs (WITH clause entries) that are never referenced in the query body."""
 
     def __init__(self, severity: str = "warn") -> None:
@@ -17,9 +17,6 @@ class NoUnusedCteRule(FormatterRule):
     @property
     def name(self) -> str:
         return "no-unused-cte"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class PreferGroupByAllRule(FormatterRule):
+class PreferGroupByAllRule(LintOnlyRule):
     """Lint: flag explicit GROUP BY col list when GROUP BY ALL would be equivalent."""
 
     def __init__(self, severity: str = "warn") -> None:
@@ -17,9 +17,6 @@ class PreferGroupByAllRule(FormatterRule):
     @property
     def name(self) -> str:
         return "prefer-group-by-all"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/src/jarify/rules/prefer_using_over_on.py
+++ b/src/jarify/rules/prefer_using_over_on.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import FormatterRule, _node_pos
+from jarify.rules.base import LintOnlyRule, _node_pos
 from jarify.types import LintViolation
 
 
-class PreferUsingOverOnRule(FormatterRule):
+class PreferUsingOverOnRule(LintOnlyRule):
     """Lint: flag ON a.col = b.col equi-joins where both sides share the same column name."""
 
     def __init__(self, severity: str = "warn") -> None:
@@ -17,9 +17,6 @@ class PreferUsingOverOnRule(FormatterRule):
     @property
     def name(self) -> str:
         return "prefer-using-over-on"
-
-    def apply(self, tree: exp.Expression) -> exp.Expression:
-        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Eight lint-only rules in `src/jarify/rules/` each repeated the same no-op `apply()` method:

```python
def apply(self, tree: exp.Expression) -> exp.Expression:
    return tree
```

This PR adds a `LintOnlyRule` intermediate base class to `rules/base.py` that provides this default. All purely lint rules now subclass `LintOnlyRule` instead of `FormatterRule` directly, removing the boilerplate from:

- `NoSelectStarRule`
- `NoSelectStarInCteRule`
- `NoUnusedCteRule`
- `NoImplicitCrossJoinRule`
- `PreferGroupByAllRule`
- `PreferUsingOverOnRule`
- `DuckdbTypeStyleRule`
- `DuckdbPreferQualifyRule`

No behaviour change — pure structural deduplication. All 128 existing tests pass.

Resolves #79

