### PR TITLE
fix(fmt): prevent double space before TABLE in AS TABLE macro return type

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -115,7 +115,7 @@ class JarifyGenerator(DuckDB.Generator):
         dynamic: bool = False,
         new_line: bool = False,
     ) -> str:
-        if not (self.pretty and self.leading_comma):
+        if not (self.pretty and self.leading_comma) or isinstance(expression, exp.Properties):
             return super().expressions(
                 expression=expression,
                 key=key,

--- a/tests/fixtures/duckdb/create_macro_table.expected.sql
+++ b/tests/fixtures/duckdb/create_macro_table.expected.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE MACRO aggregated_amount_qualification
+(
+   _scope
+  ,_level_key
+  ,_operator
+  ,_level_type
+  ,_value
+  ,_filters
+  ,_transform
+  ,_variants
+) AS TABLE
+(
+  WITH _direct_filters AS
+  (
+    SELECT
+       filter
+    FROM (
+      SELECT
+         unnest(_filters) AS filter
+    )
+    WHERE filter.context = 'direct'
+  )
+  FROM _direct_filters
+)
+;

--- a/tests/fixtures/duckdb/create_macro_table.input.sql
+++ b/tests/fixtures/duckdb/create_macro_table.input.sql
@@ -1,0 +1,1 @@
+CREATE OR REPLACE MACRO aggregated_amount_qualification (_scope, _level_key, _operator, _level_type, _value, _filters, _transform, _variants) AS TABLE (WITH _direct_filters AS (SELECT filter FROM (SELECT UNNEST(_filters) AS filter) WHERE filter.context = 'direct') SELECT * FROM _direct_filters);


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Fixes `") AS  TABLE"` double-space bug in `CREATE MACRO ... AS TABLE` formatting
- Guards the custom leading-comma `expressions()` override so it skips `exp.Properties` nodes, deferring to the base `Generator.expressions()` which correctly emits no separator for the first item
- Adds a regression fixture (`duckdb/create_macro_table`) covering a real-world table macro with a CTE body

## Root cause

`JarifyGenerator.expressions()` unconditionally prepended `" "` (a leading space) to the first item in any expression list, to align content with the `,col` lines in SELECT column lists. When sqlglot rendered a `ReturnsProperty` (the internal representation of `AS TABLE`), it called `self.expressions()` on a `Properties` node. The stray leading space was then wrapped with another space by `create_sql`, yielding `) AS  TABLE`.

## Fix

One-line guard at the top of `expressions()`.

Resolves #87
