### PR TITLE
fix(fmt): keep inline subquery in FROM on one line when it fits

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -285,7 +285,17 @@ class JarifyGenerator(DuckDB.Generator):
 
     def from_sql(self, expression: exp.From) -> str:
         table = expression.this
-        if not self.pretty or not isinstance(table, exp.Table):
+        if not self.pretty:
+            return super().from_sql(expression)
+
+        if isinstance(table, exp.Subquery):
+            # Render compactly; non-pretty seg() prepends a space, so strip it.
+            compact = self._compact_sql(expression).strip()
+            if not self.too_wide([compact]):
+                return self.seg(compact)
+            return super().from_sql(expression)
+
+        if not isinstance(table, exp.Table):
             return super().from_sql(expression)
 
         alias_str = self._table_alias_str(table)

--- a/tests/fixtures/duckdb/create_macro_table.expected.sql
+++ b/tests/fixtures/duckdb/create_macro_table.expected.sql
@@ -14,10 +14,7 @@ CREATE OR REPLACE MACRO aggregated_amount_qualification
   (
     SELECT
        filter
-    FROM (
-      SELECT
-         unnest(_filters) AS filter
-    )
+    FROM (SELECT unnest(_filters) AS filter)
     WHERE filter.context = 'direct'
   )
   FROM _direct_filters

--- a/tests/fixtures/select/from_inline_subquery.expected.sql
+++ b/tests/fixtures/select/from_inline_subquery.expected.sql
@@ -1,0 +1,5 @@
+SELECT
+   filter
+FROM (SELECT unnest(_filters) AS filter)
+WHERE filter.context = 'direct'
+;

--- a/tests/fixtures/select/from_inline_subquery.input.sql
+++ b/tests/fixtures/select/from_inline_subquery.input.sql
@@ -1,0 +1,3 @@
+SELECT filter
+FROM (SELECT UNNEST(_filters) AS filter)
+WHERE filter.context = 'direct'


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `from_sql()` now tries a compact single-line render for `exp.Subquery` in `FROM` before falling back to the parent's multi-line expansion
- Updates the `create_macro_table` fixture whose expected output had the bug
- Adds a new `select/from_inline_subquery` fixture that covers the exact reproduction case from the issue

## Details

When a subquery appears in a `FROM` clause, `from_sql()` previously short-circuited straight to `super().from_sql()` for any non-`Table` expression, which in pretty mode always wraps the subquery across multiple lines. The fix renders the clause compactly first (via `_compact_sql`), and only falls back to multi-line if the result exceeds `max_text_width`.

Resolves #88
