### PR TITLE
fix(fmt): preserve list_contains function name

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -42,7 +42,14 @@ class JarifyGenerator(DuckDB.Generator):
     # DuckDB's TRANSFORMS maps exp.Pivot to a preprocess([unqualify_columns]) transform,
     # which strips all table qualifiers from columns inside PIVOT subqueries.
     # We remove it so the dispatch falls through to pivot_sql directly, preserving qualifiers.
-    TRANSFORMS: ClassVar[dict] = {k: v for k, v in DuckDB.Generator.TRANSFORMS.items() if k is not exp.Pivot}
+    #
+    # We also remove exp.ArrayContains so dispatch falls through to arraycontains_sql,
+    # which emits `list_contains` (DuckDB's canonical name) instead of `array_contains`.
+    TRANSFORMS: ClassVar[dict] = {
+        k: v
+        for k, v in DuckDB.Generator.TRANSFORMS.items()
+        if k not in (exp.Pivot, exp.ArrayContains)
+    }
 
     # Aggregate and window function names that should be uppercased in output.
     # Derived from sqlglot's AggFunc hierarchy + RowNumber (window-only) + the
@@ -679,6 +686,15 @@ class JarifyGenerator(DuckDB.Generator):
             expressions_sql = self.expressions(expression, flat=False)
             return f"{self.seg(f'GROUP BY{modifier}')}{self.sep() if expressions_sql else ''}{expressions_sql}"
         return super().group_sql(expression)
+
+    # ------------------------------------------------------------------
+    # list_contains: preserve DuckDB's canonical name (sqlglot normalises
+    # both list_contains and array_contains to ArrayContains and emits
+    # array_contains; we override to always emit list_contains).
+    # ------------------------------------------------------------------
+
+    def arraycontains_sql(self, expression: exp.ArrayContains) -> str:
+        return self.func("list_contains", expression.this, expression.expression)
 
     # ------------------------------------------------------------------
     # Cast: prefer :: shorthand over CAST()

--- a/tests/fixtures/select/list_contains.expected.sql
+++ b/tests/fixtures/select/list_contains.expected.sql
@@ -1,0 +1,6 @@
+SELECT
+   t.id
+FROM df
+INNER JOIN t
+WHERE list_contains(df.filter.sku_keys::text[], t.sku_key)
+;

--- a/tests/fixtures/select/list_contains.input.sql
+++ b/tests/fixtures/select/list_contains.input.sql
@@ -1,0 +1,1 @@
+SELECT t.id FROM df, t WHERE list_contains(CAST(df.filter.sku_keys AS VARCHAR[]), t.sku_key)

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "jarify"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

sqlglot maps both `list_contains` and `array_contains` to an internal `ArrayContains` node and always emits `array_contains` on output. This caused the formatter to silently rewrite `list_contains(...)` expressions, which is the structural change reported in #89.

**Root cause investigation** confirmed there are no sqlglot flags or options to preserve the original function name — the normalisation is baked into the parser's `FUNCTIONS` map and the DuckDB generator's `TRANSFORMS`.

## Changes

- **`generator.py`** — exclude `exp.ArrayContains` from the `TRANSFORMS` override (alongside the existing `exp.Pivot` exclusion) so dispatch falls through to a new `arraycontains_sql` method that emits `list_contains` via `self.func`
- **`tests/fixtures/select/list_contains.{input,expected}.sql`** — fixture covering the exact reproduction from #89: `CAST(... AS VARCHAR[])` inside `list_contains` with a dotted column path

## Not changed

- `VARCHAR` → `text` normalisation (intentional, type aliases are equivalent)
- `CAST(x AS t)` → `x::t` shorthand (intentional formatting rule)

Resolves #89
