### PR TITLE
fix(fmt): preserve comma joins and extend FROM-first to multi-table queries

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -252,10 +252,16 @@ class JarifyGenerator(DuckDB.Generator):
     # ------------------------------------------------------------------
 
     def join_sql(self, expression: exp.Join) -> str:
+        has_condition = expression.args.get("on") or expression.args.get("using")
         if not expression.side and not expression.kind and not expression.method:
-            # Bare JOIN with no qualifier — normalize to INNER JOIN
-            expression = expression.copy()
-            expression.set("kind", "INNER")
+            if has_condition:
+                # Bare JOIN with a condition — normalize to INNER JOIN
+                expression = expression.copy()
+                expression.set("kind", "INNER")
+            else:
+                # Comma join (no condition) — delegate to DuckDB's renderer,
+                # which emits comma-separated syntax instead of a bare JOIN keyword
+                return super().join_sql(expression)
         elif expression.side in ("LEFT", "RIGHT") and expression.kind == "OUTER":
             # DROP redundant OUTER: LEFT OUTER JOIN → LEFT JOIN
             expression = expression.copy()
@@ -612,12 +618,26 @@ class JarifyGenerator(DuckDB.Generator):
             ):
                 return self._cte_values_sql(from_.this)
 
+            # FROM-first is safe when there are no explicit joins. Comma joins
+            # (kind=None, no on/using) are fine — sqlglot round-trips them
+            # correctly. Explicit joins (INNER, LEFT, SEMI, etc.) are excluded
+            # because sqlglot re-parses `FROM t JOIN u` differently from
+            # `SELECT * FROM t JOIN u`, breaking idempotency.
+            joins = expression.args.get("joins") or []
+            only_comma_joins = all(
+                not j.args.get("kind")
+                and not j.args.get("side")
+                and not j.args.get("method")
+                and not j.args.get("on")
+                and not j.args.get("using")
+                for j in joins
+            )
             if (
                 self._config.prefer_from_first
                 and len(exprs) == 1
                 and isinstance(exprs[0], exp.Star)
                 and not expression.args.get("distinct")
-                and not expression.args.get("joins")
+                and only_comma_joins
             ):
                 expr_copy = expression.copy()
                 expr_copy.set("expressions", [])

--- a/tests/fixtures/select/from_first.expected.sql
+++ b/tests/fixtures/select/from_first.expected.sql
@@ -9,3 +9,6 @@ FROM products
 ORDER BY
    name
 ;
+
+FROM _actual, _target, _threshold
+;

--- a/tests/fixtures/select/from_first.input.sql
+++ b/tests/fixtures/select/from_first.input.sql
@@ -1,3 +1,4 @@
 SELECT * FROM people;
 SELECT * FROM orders WHERE status = 'active';
 SELECT * FROM products ORDER BY name;
+SELECT * FROM _actual, _target, _threshold;

--- a/tests/fixtures/select/list_contains.expected.sql
+++ b/tests/fixtures/select/list_contains.expected.sql
@@ -1,6 +1,5 @@
 SELECT
    t.id
-FROM df
-INNER JOIN t
+FROM df, t
 WHERE list_contains(df.filter.sku_keys::text[], t.sku_key)
 ;

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "jarify"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Two related fixes for comma-join and FROM-first handling:

1. **Preserve comma joins** — `FROM a, b, c` was being rewritten as `INNER JOIN` without an `ON` clause.
2. **Extend FROM-first to multi-table queries** — `SELECT * FROM a, b` now correctly rewrites to `FROM a, b`.

## Root causes

**Comma joins → INNER JOIN:** sqlglot parses `FROM a, b` as `Join` nodes with `kind=None, on=None` — the same as an explicit bare join before the kind is set. The `join_sql` override normalised all `kind=None` joins to `INNER`, catching comma joins as an unintended side effect.

**FROM-first blocked on joins:** The `select_sql` FROM-first guard checked `not expression.args.get("joins")`, which prevented any multi-table query from getting FROM-first treatment — including simple comma-joined ones.

## Fixes

**`join_sql`:** Gate the `kind=None → INNER` normalisation on the presence of an `on` or `using` clause:

- `JOIN t ON x = y` → `INNER JOIN t ON x = y` ✓
- `FROM a, b, c` → `FROM a, b, c` ✓ (preserved)
- `LEFT OUTER JOIN` → `LEFT JOIN` ✓ (unchanged)

**`select_sql`:** Replace the blanket joins guard with a finer check — FROM-first applies when all joins are comma-style (no `kind`, `side`, `method`, `on`, or `using`). Explicit joins (INNER, LEFT, SEMI, …) retain `SELECT *` because sqlglot re-parses `FROM t JOIN u` differently from `SELECT * FROM t JOIN u`, which would break idempotency.

Resolves #96
