### PR TITLE
ci: replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_ID }}
+          client-id: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_ID }}
           private-key: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_ID }}
+          client-id: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_ID }}
           private-key: ${{ steps.doppler.outputs.WORKFLOW_CLIENT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Replace deprecated `app-id` input with `client-id` in the `Generate token` step of `publish.yml` and `prepare-release.yml`
- `actions/create-github-app-token@v3` deprecated `app-id` in favour of `client-id`, causing a warning annotation on every workflow run

## Files changed

- `.github/workflows/publish.yml`
- `.github/workflows/prepare-release.yml`

Resolves #102
