### PR TITLE
fix(fmt): preserve indentation of whole-line template placeholders

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -46,9 +46,7 @@ class JarifyGenerator(DuckDB.Generator):
     # We also remove exp.ArrayContains so dispatch falls through to arraycontains_sql,
     # which emits `list_contains` (DuckDB's canonical name) instead of `array_contains`.
     TRANSFORMS: ClassVar[dict] = {
-        k: v
-        for k, v in DuckDB.Generator.TRANSFORMS.items()
-        if k not in (exp.Pivot, exp.ArrayContains)
+        k: v for k, v in DuckDB.Generator.TRANSFORMS.items() if k not in (exp.Pivot, exp.ArrayContains)
     }
 
     # Aggregate and window function names that should be uppercased in output.

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -92,7 +92,7 @@ def _extract_line_rust_fmt_placeholders(sql: str) -> tuple[str, list[tuple[str, 
         if _RUST_FMT_LINE_RE.match(lines[i]):
             m = _RUST_FMT_RE.search(lines[i])
             assert m is not None
-            placeholder = m.group(0)
+            placeholder = lines[i].rstrip("\r\n")
             anchor: str | None = None
             for j in range(i + 1, len(lines)):
                 candidate = lines[j].strip()

--- a/tests/fixtures/templates/rust_fmt_indented_placeholders.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_indented_placeholders.expected.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE TABLE programs AS
+(
+  WITH _programs AS
+  (
+    FROM programs
+    {where_clause}
+  )
+  {with_clause}
+  SELECT
+     p.*
+  FROM _programs p
+  {join_clause}
+)
+;

--- a/tests/fixtures/templates/rust_fmt_indented_placeholders.input.sql
+++ b/tests/fixtures/templates/rust_fmt_indented_placeholders.input.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE TABLE programs AS
+(
+  WITH _programs AS
+  (
+    FROM programs
+    {where_clause}
+  )
+  {with_clause}
+  SELECT
+     p.*
+  FROM _programs p
+  {join_clause}
+)
+;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -201,6 +201,14 @@ class TestExtractReinsertLinePlaceholders:
         restored = _reinsert_line_rust_fmt_placeholders(stripped, insertions)
         assert restored == sql
 
+    def test_round_trip_preserves_indented_placeholder(self) -> None:
+        sql = "(\n  FROM programs\n    {where_clause}\n)\n;\n"
+        stripped, insertions = _extract_line_rust_fmt_placeholders(sql)
+        assert "{where_clause}" not in stripped
+        assert insertions[0][0] == "    {where_clause}"
+        restored = _reinsert_line_rust_fmt_placeholders(stripped, insertions)
+        assert restored == sql
+
     def test_no_placeholders_returns_unchanged(self) -> None:
         sql = "SELECT a FROM t WHERE x = 1\n;\n"
         stripped, insertions = _extract_line_rust_fmt_placeholders(sql)


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Fix `_extract_line_rust_fmt_placeholders` in `parser.py` to preserve the leading whitespace of whole-line template placeholders
- Add a unit test asserting that indented placeholders round-trip cleanly through extract/reinsert
- Add a fixture pair (`templates/rust_fmt_indented_placeholders`) that exercises the full `format_sql` path with the `tmp/example.sql` template pattern

## Root cause

`_extract_line_rust_fmt_placeholders` was storing `m.group(0)` — the bare `{placeholder}` text — which discards any leading whitespace from the original line. `_reinsert_line_rust_fmt_placeholders` then emitted that bare token with no indentation, silently corrupting already-correct files on every `jarify fmt` run.

The fix is one line: capture `lines[i].rstrip("\r\n")` instead of `m.group(0)` so the full line content (including its original indent) is stored and re-emitted verbatim.

## Test plan

- [ ] `uv run --all-groups python -m pytest` — all 63 tests pass
- [ ] `uv run --all-groups python -m ruff check src/ tests/` — no lint errors
- [ ] Verify `jarify fmt tmp/example.sql` is now a no-op on the already-formatted file

Resolves #104
