### PR TITLE
fix(fmt): preserve consecutive whole-line template placeholder order

### DIFF
--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -73,67 +73,83 @@ def _unmask_rust_fmt_placeholders(sql: str, mapping: dict[str, str]) -> str:
     return sql
 
 
-def _extract_line_rust_fmt_placeholders(sql: str) -> tuple[str, list[tuple[str, str | None]]]:
+def _extract_line_rust_fmt_placeholders(
+    sql: str,
+) -> tuple[str, list[tuple[list[str], str | None]]]:
     """Strip whole-line Rust format placeholder lines from ``sql``.
 
     Used by the formatter so the stripped SQL can be formatted normally, then
     the placeholders can be re-inserted at the correct positions afterward.
 
-    Returns ``(stripped_sql, [(placeholder, anchor), ...])``.  *anchor* is the
-    stripped text of the first non-blank line that followed the placeholder; it
-    is ``None`` when the placeholder is at the very end of the file.
+    Returns ``(stripped_sql, [(group, anchor), ...])``.  *group* is a list of
+    one or more consecutive placeholder lines (their full text, leading
+    whitespace preserved).  *anchor* is the stripped text of the first
+    non-blank, non-placeholder line after the group; it is ``None`` when no
+    such line exists.  Grouping consecutive placeholders together ensures they
+    are re-inserted in their original order before the same anchor occurrence.
     """
     lines = sql.splitlines(keepends=True)
     result_lines: list[str] = []
-    insertions: list[tuple[str, str | None]] = []
+    insertions: list[tuple[list[str], str | None]] = []
 
     i = 0
     while i < len(lines):
         if _RUST_FMT_LINE_RE.match(lines[i]):
-            m = _RUST_FMT_RE.search(lines[i])
-            assert m is not None
-            placeholder = lines[i].rstrip("\r\n")
+            # Collect all adjacent placeholder lines into one group so they
+            # are re-inserted together (preserving relative order) before a
+            # single anchor occurrence.
+            group: list[str] = []
+            while i < len(lines) and _RUST_FMT_LINE_RE.match(lines[i]):
+                m = _RUST_FMT_RE.search(lines[i])
+                assert m is not None
+                group.append(lines[i].rstrip("\r\n"))
+                i += 1
             anchor: str | None = None
-            for j in range(i + 1, len(lines)):
+            for j in range(i, len(lines)):
                 candidate = lines[j].strip()
-                if candidate:
+                if candidate and not _RUST_FMT_LINE_RE.match(lines[j]):
                     anchor = candidate
                     break
-            insertions.append((placeholder, anchor))
+            insertions.append((group, anchor))
         else:
             result_lines.append(lines[i])
-        i += 1
+            i += 1
 
     return "".join(result_lines), insertions
 
 
-def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[str, str | None]]) -> str:
-    """Re-insert whole-line placeholders into formatted SQL before their anchor lines.
+def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[str], str | None]]) -> str:
+    """Re-insert whole-line placeholder groups into formatted SQL.
 
-    Each placeholder is inserted on its own line immediately before the first
-    occurrence of its anchor text (compared after stripping whitespace).
-    Placeholders with no anchor are appended at the end before the final newline.
+    Each group is inserted immediately before the first occurrence of its
+    anchor line (compared after stripping whitespace), preserving all lines in
+    the group in their original order.  Groups with no anchor are appended at
+    the end.
     """
     if not insertions:
         return sql
 
     lines = sql.splitlines(keepends=True)
-    # Work through insertions in order; pop the first matching anchor each time
+    # Work through groups in order; pop the first matching anchor each time so
+    # that two groups with the same anchor text land before different
+    # occurrences of that anchor in the formatted SQL.
     pending = list(insertions)
     result: list[str] = []
 
     for line in lines:
         stripped = line.strip()
-        for idx, (placeholder, anchor) in enumerate(pending):
+        for idx, (group, anchor) in enumerate(pending):
             if anchor is not None and stripped == anchor:
-                result.append(placeholder + "\n")
+                for placeholder in group:
+                    result.append(placeholder + "\n")
                 pending.pop(idx)
                 break
         result.append(line)
 
-    # Append any remaining (no-anchor) placeholders before the trailing newline
-    for placeholder, _ in pending:
-        result.append(placeholder + "\n")
+    # Append any remaining (no-anchor) groups before the trailing newline
+    for group, _ in pending:
+        for placeholder in group:
+            result.append(placeholder + "\n")
 
     return "".join(result)
 

--- a/tests/fixtures/templates/rust_fmt_consecutive_placeholders.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_consecutive_placeholders.expected.sql
@@ -1,0 +1,8 @@
+{program_filter}
+{example_filter}
+CREATE OR REPLACE TABLE offers AS
+SELECT
+   o.*
+FROM offers         o
+INNER JOIN programs p ON o.program_key = p.program_key
+;

--- a/tests/fixtures/templates/rust_fmt_consecutive_placeholders.input.sql
+++ b/tests/fixtures/templates/rust_fmt_consecutive_placeholders.input.sql
@@ -1,0 +1,9 @@
+{program_filter}
+{example_filter}
+
+CREATE OR REPLACE TABLE offers AS
+SELECT
+   o.*
+FROM offers o
+INNER JOIN programs p ON o.program_key = p.program_key
+;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -176,7 +176,7 @@ class TestExtractReinsertLinePlaceholders:
         stripped, insertions = _extract_line_rust_fmt_placeholders(sql)
         assert "{where_clause}" not in stripped
         assert len(insertions) == 1
-        assert insertions[0][0] == "{where_clause}"
+        assert insertions[0][0] == ["{where_clause}"]
 
     def test_anchor_is_next_non_blank_line(self) -> None:
         sql = "FROM examples\n{where_clause}\n;"
@@ -205,7 +205,7 @@ class TestExtractReinsertLinePlaceholders:
         sql = "(\n  FROM programs\n    {where_clause}\n)\n;\n"
         stripped, insertions = _extract_line_rust_fmt_placeholders(sql)
         assert "{where_clause}" not in stripped
-        assert insertions[0][0] == "    {where_clause}"
+        assert insertions[0][0] == ["    {where_clause}"]
         restored = _reinsert_line_rust_fmt_placeholders(stripped, insertions)
         assert restored == sql
 
@@ -214,3 +214,24 @@ class TestExtractReinsertLinePlaceholders:
         stripped, insertions = _extract_line_rust_fmt_placeholders(sql)
         assert stripped == sql
         assert insertions == []
+
+    def test_consecutive_placeholders_form_one_group(self) -> None:
+        sql = "{program_filter}\n{example_filter}\n\nCREATE TABLE t AS SELECT 1\n;\n"
+        _, insertions = _extract_line_rust_fmt_placeholders(sql)
+        # Consecutive placeholders collapse into a single group with a shared
+        # SQL anchor so they are re-inserted together in their original order.
+        assert len(insertions) == 1
+        assert insertions[0] == (
+            ["{program_filter}", "{example_filter}"],
+            "CREATE TABLE t AS SELECT 1",
+        )
+
+    def test_consecutive_placeholders_reinserted_in_order(self) -> None:
+        sql = "{program_filter}\n{example_filter}\n\nCREATE TABLE t AS SELECT 1\n;\n"
+        stripped, insertions = _extract_line_rust_fmt_placeholders(sql)
+        restored = _reinsert_line_rust_fmt_placeholders(stripped, insertions)
+        lines = restored.splitlines()
+        prog_idx = lines.index("{program_filter}")
+        ex_idx = lines.index("{example_filter}")
+        create_idx = next(i for i, ln in enumerate(lines) if ln.startswith("CREATE TABLE"))
+        assert prog_idx < ex_idx < create_idx


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Groups adjacent whole-line Rust fmt placeholder lines into a single insertion unit so they share one real SQL anchor and are always re-inserted in their original order after formatting
- Updates `_extract_line_rust_fmt_placeholders` to collect consecutive placeholder lines into a `list[str]` group before scanning for a non-placeholder anchor
- Updates `_reinsert_line_rust_fmt_placeholders` to insert all lines in a group before the first matching anchor occurrence
- Adds a fixture pair and two unit tests covering the consecutive-placeholder case

## Before / After

Given a template with two consecutive top-level placeholders, `fmt` used to move the first placeholder to the end of the file. After this fix, both placeholders stay at the top in their original order.

Resolves #107
