### PR TITLE
fix(fmt): preserve blank lines between placeholder blocks and SQL

### DIFF
--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -75,22 +75,26 @@ def _unmask_rust_fmt_placeholders(sql: str, mapping: dict[str, str]) -> str:
 
 def _extract_line_rust_fmt_placeholders(
     sql: str,
-) -> tuple[str, list[tuple[list[str], str | None]]]:
+) -> tuple[str, list[tuple[list[str], list[str], str | None]]]:
     """Strip whole-line Rust format placeholder lines from ``sql``.
 
     Used by the formatter so the stripped SQL can be formatted normally, then
     the placeholders can be re-inserted at the correct positions afterward.
 
-    Returns ``(stripped_sql, [(group, anchor), ...])``.  *group* is a list of
-    one or more consecutive placeholder lines (their full text, leading
-    whitespace preserved).  *anchor* is the stripped text of the first
-    non-blank, non-placeholder line after the group; it is ``None`` when no
-    such line exists.  Grouping consecutive placeholders together ensures they
-    are re-inserted in their original order before the same anchor occurrence.
+    Returns ``(stripped_sql, [(group, trailing_blanks, anchor), ...])``.
+    *group* is a list of one or more consecutive placeholder lines (their full
+    text, leading whitespace preserved).  *trailing_blanks* is a list of blank
+    lines that immediately follow the group — they are consumed here so the
+    formatter does not strip them as leading whitespace, and re-emitted by
+    ``_reinsert_line_rust_fmt_placeholders``.  *anchor* is the stripped text
+    of the first non-blank, non-placeholder line after the group; it is
+    ``None`` when no such line exists.  Grouping consecutive placeholders
+    together ensures they are re-inserted in their original order before the
+    same anchor occurrence.
     """
     lines = sql.splitlines(keepends=True)
     result_lines: list[str] = []
-    insertions: list[tuple[list[str], str | None]] = []
+    insertions: list[tuple[list[str], list[str], str | None]] = []
 
     i = 0
     while i < len(lines):
@@ -104,13 +108,22 @@ def _extract_line_rust_fmt_placeholders(
                 assert m is not None
                 group.append(lines[i].rstrip("\r\n"))
                 i += 1
+            # Consume blank lines that immediately follow the placeholder
+            # group.  Without this, the formatter receives SQL beginning with
+            # blank lines and strips them, making fmt non-idempotent on files
+            # that separate a placeholder block from the first SQL statement
+            # with a blank line.
+            trailing_blanks: list[str] = []
+            while i < len(lines) and not lines[i].strip():
+                trailing_blanks.append(lines[i])
+                i += 1
             anchor: str | None = None
             for j in range(i, len(lines)):
                 candidate = lines[j].strip()
                 if candidate and not _RUST_FMT_LINE_RE.match(lines[j]):
                     anchor = candidate
                     break
-            insertions.append((group, anchor))
+            insertions.append((group, trailing_blanks, anchor))
         else:
             result_lines.append(lines[i])
             i += 1
@@ -118,13 +131,14 @@ def _extract_line_rust_fmt_placeholders(
     return "".join(result_lines), insertions
 
 
-def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[str], str | None]]) -> str:
+def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[str], list[str], str | None]]) -> str:
     """Re-insert whole-line placeholder groups into formatted SQL.
 
     Each group is inserted immediately before the first occurrence of its
     anchor line (compared after stripping whitespace), preserving all lines in
-    the group in their original order.  Groups with no anchor are appended at
-    the end.
+    the group in their original order.  Trailing blank lines recorded during
+    extraction are emitted after the group and before the anchor.  Groups with
+    no anchor are appended at the end.
     """
     if not insertions:
         return sql
@@ -138,18 +152,20 @@ def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[s
 
     for line in lines:
         stripped = line.strip()
-        for idx, (group, anchor) in enumerate(pending):
+        for idx, (group, trailing_blanks, anchor) in enumerate(pending):
             if anchor is not None and stripped == anchor:
                 for placeholder in group:
                     result.append(placeholder + "\n")
+                result.extend(trailing_blanks)
                 pending.pop(idx)
                 break
         result.append(line)
 
     # Append any remaining (no-anchor) groups before the trailing newline
-    for group, _ in pending:
+    for group, trailing_blanks, _ in pending:
         for placeholder in group:
             result.append(placeholder + "\n")
+        result.extend(trailing_blanks)
 
     return "".join(result)
 

--- a/tests/fixtures/templates/rust_fmt_consecutive_placeholders.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_consecutive_placeholders.expected.sql
@@ -1,5 +1,6 @@
 {program_filter}
 {example_filter}
+
 CREATE OR REPLACE TABLE offers AS
 SELECT
    o.*

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -181,7 +181,7 @@ class TestExtractReinsertLinePlaceholders:
     def test_anchor_is_next_non_blank_line(self) -> None:
         sql = "FROM examples\n{where_clause}\n;"
         _, insertions = _extract_line_rust_fmt_placeholders(sql)
-        assert insertions[0][1] == ";"
+        assert insertions[0][2] == ";"
 
     def test_reinsert_restores_before_anchor(self) -> None:
         sql = "FROM examples\n{where_clause}\n;"
@@ -223,8 +223,20 @@ class TestExtractReinsertLinePlaceholders:
         assert len(insertions) == 1
         assert insertions[0] == (
             ["{program_filter}", "{example_filter}"],
+            ["\n"],
             "CREATE TABLE t AS SELECT 1",
         )
+
+    def test_blank_lines_after_placeholder_block_are_preserved(self) -> None:
+        sql = "{program_filter}\n{example_filter}\n\nCREATE TABLE t AS SELECT 1\n;\n"
+        stripped, insertions = _extract_line_rust_fmt_placeholders(sql)
+        # The blank line between the placeholder block and the SQL must be
+        # consumed during extraction so the formatter does not see it as
+        # leading whitespace (and strip it).
+        assert not stripped.startswith("\n"), "blank line must not leak into stripped SQL"
+        # After reinsertion the blank line must be restored.
+        restored = _reinsert_line_rust_fmt_placeholders(stripped, insertions)
+        assert restored == sql
 
     def test_consecutive_placeholders_reinserted_in_order(self) -> None:
         sql = "{program_filter}\n{example_filter}\n\nCREATE TABLE t AS SELECT 1\n;\n"


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Consumes blank lines that immediately follow a whole-line placeholder block during extraction, preventing the formatter from discarding them as leading whitespace
- Re-emits those blank lines between the placeholder group and its anchor line during reinsertion
- Updates the `rust_fmt_consecutive_placeholders` fixture to reflect the now-correct expected output (blank line preserved)
- Adds `test_blank_lines_after_placeholder_block_are_preserved` to cover the round-trip and the idempotency property directly at the unit level

## Why it broke

`_extract_line_rust_fmt_placeholders` left blank lines after a placeholder block in the stripped SQL. The formatter received SQL beginning with a blank line and normalised it away. On reinsertion the blank line was simply gone — making `fmt` non-idempotent on files that separate a placeholder block from the first SQL statement with a blank line.

## Test plan

- [x] `uv run python -m pytest tests/test_parser.py tests/test_fixtures.py` — all 67 tests pass, including the new unit test and the idempotency fixture test
- [x] `mise run lint` — clean

Resolves #109
