### PR TITLE
fix(fmt): lowercase boolean literals (true/false)

### DIFF
--- a/.agents/skills/add-formatter-rule.md
+++ b/.agents/skills/add-formatter-rule.md
@@ -1,0 +1,96 @@
+---
+name: add-formatter-rule
+description: Use when adding or changing a formatting rule in JarifyGenerator. Ensures sqlglot defaults are audited, the override is placed correctly, tests and fixtures are added, and the style guide is updated.
+---
+
+# Add Formatter Rule
+
+## Overview
+
+Jarify overrides sqlglot's `DuckDB.Generator` to enforce its opinionated style. sqlglot's defaults often diverge from jarify's style — missing an override silently produces wrong output (e.g. uppercase `TRUE`/`FALSE` before `boolean_sql()` was added). This skill guards against that gap.
+
+## Workflow
+
+1. **Audit sqlglot's default first**
+
+   Before writing any code, confirm what sqlglot emits for the construct you're targeting:
+
+   ```python
+   from sqlglot import parse_one
+   from sqlglot.dialects import DuckDB
+   print(DuckDB().generate(parse_one("<your SQL>", dialect="duckdb")))
+   ```
+
+   If the output already matches jarify style, no override is needed. If it doesn't, continue.
+
+2. **Add the override to `JarifyGenerator`**
+
+   All formatting overrides live in `src/jarify/generator.py`. Find the most relevant section using the section headers (e.g. `# Data types`, `# Function name casing`). Place the new method near related overrides.
+
+   Follow the existing pattern — most overrides are one-liners:
+   ```python
+   def boolean_sql(self, expression: exp.Boolean) -> str:
+       return "true" if expression.this else "false"
+   ```
+
+3. **Add a fixture pair**
+
+   ```bash
+   # Input file
+   echo "SELECT a FROM t WHERE flag = true" > tests/fixtures/select/<name>.input.sql
+
+   # Generate expected output
+   uv run python -m pytest tests/test_fixtures.py --update-fixtures
+
+   # Review the generated .expected.sql — confirm it matches jarify style
+   ```
+
+4. **Update existing fixtures if needed**
+
+   Run the full suite to find fixtures that now produce different output:
+   ```bash
+   uv run python -m pytest tests/test_fixtures.py -v
+   ```
+   Regenerate any that fail due to the new rule:
+   ```bash
+   uv run python -m pytest tests/test_fixtures.py --update-fixtures
+   ```
+   Review each regenerated file to confirm the change is intentional.
+
+5. **Update `docs/sql-style-guide.md`**
+
+   Every formatting rule must have a documented bad/good example in `docs/sql-style-guide.md`. Place it in the Formatting Rules section, near related rules.
+
+6. **Verify**
+
+   ```bash
+   uv run python -m pytest tests/
+   ```
+
+   All tests must pass before committing.
+
+## Known sqlglot Defaults That Jarify Overrides
+
+| Construct | sqlglot default | Jarify override | Method |
+|-----------|----------------|-----------------|--------|
+| Boolean literals | `TRUE` / `FALSE` | `true` / `false` | `boolean_sql()` |
+| Data types | `TEXT`, `INT`, … | `text`, `int`, … | `datatype_sql()` |
+| Aggregate/window functions | lowercase | `COUNT`, `SUM`, … | `normalize_func()` |
+| Scalar functions | varies | lowercase | `normalize_func()` |
+| Column expressions | trailing commas | leading commas | `expressions()` |
+| Bare `JOIN` | `JOIN` | `INNER JOIN` | rule in `rules/` |
+
+When adding a new override, add it to this table.
+
+## Guardrails
+
+- Never assume sqlglot's output matches jarify style — always audit first.
+- Do not add a `_sql()` override without a corresponding fixture and style-guide entry.
+- Do not regenerate fixtures without reviewing each diff — a regenerated file that looks wrong means the override is wrong.
+- If an existing expected fixture changes because of your new rule, that is intentional; review and commit it alongside the rule.
+
+## Common Mistakes
+
+- Adding an override but forgetting to update `docs/sql-style-guide.md` — the style guide is the authoritative reference for users and AI agents.
+- Running `--update-fixtures` blindly without inspecting output — regenerated files can silently encode bugs.
+- Placing a new override far from related methods — keep `boolean_sql()` near `datatype_sql()`, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ Always run `mise run check` before committing and ensure all tests pass.
 
 ## Adding or changing a rule
 
+Load `.agents/skills/add-formatter-rule.md` before implementing a new or changed formatting rule — it covers the full workflow including sqlglot default auditing, fixture generation, and style-guide updates.
+
 1. **Formatting rules** live in `src/jarify/generator.py` (override a generator method) or `src/jarify/rules/` (subclass `FormatterRule` and implement `apply()`).
 2. **Lint-only rules** live in `src/jarify/rules/` (implement `check()`, leave `apply()` as a no-op).
 3. Register new rules in `src/jarify/rules/__init__.py` and add a config knob to `src/jarify/config.py`.

--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -51,6 +51,27 @@ CREATE TABLE t
 
 ---
 
+### Boolean literals — lowercase
+
+Boolean literals are always lowercase: `true` and `false`.
+
+**Bad**
+```sql
+SELECT a FROM t WHERE a.active = TRUE AND a.deleted = FALSE
+```
+
+**Good**
+```sql
+SELECT
+   a
+FROM t
+WHERE a.active = true
+  AND a.deleted = false
+;
+```
+
+---
+
 ### Functions — aggregate and window uppercase, scalar lowercase
 
 Aggregate and window functions (`COUNT`, `SUM`, `AVG`, `ROW_NUMBER`, `RANK`, `LEAD`, etc.) are always uppercase. All other DuckDB built-in functions (`regexp_extract`, `strftime`, `date_trunc`, etc.) remain lowercase.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -767,6 +767,9 @@ class JarifyGenerator(DuckDB.Generator):
     def datatype_sql(self, expression: exp.DataType) -> str:
         return super().datatype_sql(expression).lower()
 
+    def boolean_sql(self, expression: exp.Boolean) -> str:
+        return "true" if expression.this else "false"
+
     # ------------------------------------------------------------------
     # CREATE MACRO: opening paren on its own line, leading-comma params
     # ------------------------------------------------------------------

--- a/tests/fixtures/complex/real_world.expected.sql
+++ b/tests/fixtures/complex/real_world.expected.sql
@@ -17,7 +17,7 @@ WITH _latest_version AS
 (
   FROM read_parquet(
      's3://' || getvariable('tigris_bucket') || '/dataops/*/*/relevant_skus.parquet'
-    ,hive_partitioning = TRUE
+    ,hive_partitioning = true
     ,hive_types = {'program_supplier_key': text, 'time_frame': int}
   )
   WHERE time_frame = getvariable('time_frame')
@@ -26,7 +26,7 @@ WITH _latest_version AS
 (
   FROM read_parquet(
      's3://' || getvariable('tigris_bucket') || '/dataops/*/*/enrollments.parquet'
-    ,hive_partitioning = TRUE
+    ,hive_partitioning = true
     ,hive_types = {'program_supplier_key': text, 'time_frame': int}
   )
   WHERE time_frame = getvariable('time_frame')
@@ -37,7 +37,7 @@ WITH _latest_version AS
      *
   FROM read_parquet(
      's3://' || getvariable('tigris_bucket') || '/global-catalog/*/sku_catalog.parquet'
-    ,hive_partitioning = TRUE
+    ,hive_partitioning = true
     ,hive_types = {'version': text}
   )
   SEMI JOIN _latest_version USING (version)
@@ -48,7 +48,7 @@ WITH _latest_version AS
      *
   FROM read_parquet(
      's3://' || getvariable('tigris_bucket') || '/global-catalog/*/prices.parquet'
-    ,hive_partitioning = TRUE
+    ,hive_partitioning = true
     ,hive_types = {'version': text}
   )
   SEMI JOIN _latest_version USING (version)
@@ -70,7 +70,7 @@ CROSS JOIN (
      participant_key
   FROM _enrollments
 ) AS all_e
-LEFT JOIN _enrollments e ON e.participant_key = all_e.participant_key AND e.program_supplier_key = rs.program_supplier_key AND e.enabled = TRUE
+LEFT JOIN _enrollments e ON e.participant_key = all_e.participant_key AND e.program_supplier_key = rs.program_supplier_key AND e.enabled = true
 LEFT JOIN _prices p ON sc.version = p.version AND sc.sku_key = p.sku_key AND p.end_date IS NULL
 ORDER BY
    manufacturer_label

--- a/tests/fixtures/select/boolean_literals.expected.sql
+++ b/tests/fixtures/select/boolean_literals.expected.sql
@@ -1,0 +1,8 @@
+SELECT
+   a.id
+  ,a.active = true
+  ,b.deleted = false
+FROM accounts   a
+INNER JOIN bans b ON b.account_id = a.id
+WHERE a.verified = true
+;

--- a/tests/fixtures/select/boolean_literals.input.sql
+++ b/tests/fixtures/select/boolean_literals.input.sql
@@ -1,0 +1,9 @@
+select
+    a.id
+    , a.active = true
+    , b.deleted = false
+from accounts as a
+inner join bans as b
+    on b.account_id = a.id
+where a.verified = true
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Override `boolean_sql()` in `JarifyGenerator` to emit lowercase `true` / `false`
- Update `real_world.expected.sql` fixture (had uppercase `TRUE` / `FALSE`)
- Add new `select/boolean_literals` fixture as a regression test
- Add boolean literals section to `docs/sql-style-guide.md`
- Add `.agents/skills/add-formatter-rule.md` — a local skill guiding agents through the full workflow for adding a `JarifyGenerator` override (audit sqlglot defaults, add override, add fixture, update style guide)
- Update `AGENTS.md` to reference the new skill

## Root Cause

`JarifyGenerator` did not override `boolean_sql()`, so sqlglot's default returned uppercase `TRUE` / `FALSE`. This was inconsistent with the formatter's treatment of data types (`datatype_sql()` is already lowercased) and non-aggregate function names.

## Verification

All 166 tests pass (`uv run python -m pytest tests/`).

Resolves #113
