### PR TITLE
fix(fmt): remove = operator alignment in WHERE clauses

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -188,27 +188,20 @@ HAVING COUNT(*) > 1
 
 ### WHERE — `=` operator column alignment
 
-When a `WHERE` clause contains two or more equality (`=`) comparisons anywhere in the condition tree, the left-hand sides of all **top-level** `AND` equality conditions are right-padded so that the `=` signs align vertically. The target column is the longest LHS (across all `=` in the clause, including nested ones) plus two spaces.
+When a `WHERE` clause contains two or more equality (`=`) comparisons anywhere in the condition tree, the left-hand sides of all **top-level** `AND` equality conditions are right-padded so that the `=` signs align vertically. The target column is the longest LHS (across all `=` in the clause, including nested ones) plus one space.
 
 Parenthesised compound conditions (e.g. `(a = b OR c IS NULL)`) that appear as direct `AND` operands are kept on a single line.
 
 **Bad**
 ```sql
-WHERE p.time_frame = _time_frame
-  AND e.participant_key = _participant_key
-  AND e.enabled
-  AND (
-    p.program_supplier_key = _program_supplier_key
-    OR _program_supplier_key IS NULL
-  )
+WHERE type = _property_type
+  AND level_type = _property_level_type
 ```
 
 **Good**
 ```sql
-WHERE p.time_frame            = _time_frame
-  AND e.participant_key       = _participant_key
-  AND e.enabled
-  AND (p.program_supplier_key = _program_supplier_key OR _program_supplier_key IS NULL)
+WHERE type       = _property_type
+  AND level_type = _property_level_type
 ```
 
 ---

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -7,7 +7,7 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - AND/OR conditions always on separate lines in pretty mode
 - WHERE/HAVING/ON: first condition inline with keyword, AND/OR right-justified
   so all condition content aligns at the same column; = operators in WHERE
-  top-level AND conditions are column-aligned (padded to max LHS width + 2)
+  top-level AND conditions are column-aligned (padded to max LHS width + 1)
 - CTE: opening paren on its own line, comma-prefix separator
 - Consistent keyword casing; DuckDB functions in lowercase
 - IS NOT NULL preserved (not rewritten to NOT x IS NULL)
@@ -455,7 +455,8 @@ class JarifyGenerator(DuckDB.Generator):
 
         When the top-level condition is a pure AND chain the = signs in simple
         equality conditions are padded so they all align at the same column.
-        The target column is max(LHS width across all EQ in WHERE) + 2.
+        The target column is max(LHS width across all EQ in WHERE) + 1,
+        ensuring exactly one space between the longest LHS and its = sign.
 
         Parenthesised conditions that are direct AND operands (e.g. compound OR
         filters) are rendered on a single line rather than expanded.
@@ -471,7 +472,7 @@ class JarifyGenerator(DuckDB.Generator):
         # Max EQ LHS width across entire WHERE tree (including nested EQs)
         eq_lhs_widths = [len(self.sql(eq.this)) for eq in expression.find_all(exp.EQ)]
         # Only align when there are at least 2 EQ comparisons total
-        target = (max(eq_lhs_widths) + 2) if len(eq_lhs_widths) >= 2 else 0
+        target = (max(eq_lhs_widths) + 1) if len(eq_lhs_widths) >= 2 else 0
 
         result: list[str] = []
         for i, cond in enumerate(conditions):
@@ -479,10 +480,8 @@ class JarifyGenerator(DuckDB.Generator):
                 lhs = self.sql(cond.this)
                 rhs = self.sql(cond.expression)
                 cond_str = f"{lhs.ljust(target)}= {rhs}" if "\n" not in lhs else self.sql(cond)
-            elif isinstance(cond, exp.Paren):
-                cond_str = self._compact_sql(cond)
             else:
-                cond_str = self.sql(cond)
+                cond_str = self._compact_sql(cond) if isinstance(cond, exp.Paren) else self.sql(cond)
 
             if i == 0:
                 result.append(f"WHERE {cond_str}")

--- a/tests/fixtures/duckdb/create_macro.expected.sql
+++ b/tests/fixtures/duckdb/create_macro.expected.sql
@@ -8,8 +8,8 @@ CREATE OR REPLACE MACRO get_programs_json
   SELECT
      json_object('programs', json_group_array(json_object('name', program_name, 'supplier', supplier_name)))
   FROM programs
-  WHERE participant_key  = _participant_key
-    AND time_frame       = _time_frame
-    AND supplier_key     = _program_supplier_key
+  WHERE participant_key = _participant_key
+    AND time_frame      = _time_frame
+    AND supplier_key    = _program_supplier_key
 )
 ;

--- a/tests/fixtures/select/where_eq_alignment.expected.sql
+++ b/tests/fixtures/select/where_eq_alignment.expected.sql
@@ -2,8 +2,8 @@ SELECT
    *
 FROM _programs          p
 INNER JOIN _enrollments e ON e.participant_key = p.participant_key
-WHERE p.time_frame            = _time_frame
-  AND e.participant_key       = _participant_key
+WHERE p.time_frame           = _time_frame
+  AND e.participant_key      = _participant_key
   AND e.enabled
   AND (p.program_supplier_key = _program_supplier_key OR _program_supplier_key IS NULL)
 ;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot CLI (Claude Sonnet 4.6) on behalf of @johnallen3d.

## Summary

Fixes the `=` operator alignment in `WHERE` clauses. The formatter was using `max(LHS widths) + 2` as the alignment target, which shifted the `=` one column past the natural alignment point — causing every `jarify fmt` run to modify already-correctly-aligned files.

Changed the target to `max(LHS widths) + 1` so exactly one space separates the longest LHS from its `=` sign. Files aligned to this convention are now stable across repeated format runs.

**Before (+ 2, unstable):**
```sql
WHERE type        = _property_type
  AND level_type  = _property_level_type
```

**After (+ 1, stable):**
```sql
WHERE type       = _property_type
  AND level_type = _property_level_type
```

## Changes

- `src/jarify/generator.py` — changed alignment target from `max + 2` to `max + 1`
- `tests/fixtures/select/where_eq_alignment.expected.sql` — updated fixture
- `tests/fixtures/duckdb/create_macro.expected.sql` — updated fixture
- `docs/sql-style-guide.md` — restored section with corrected formula and example

## Verification

All 165 tests pass; `ruff check` clean. `jarify fmt --diff tmp/example.sql` produces no diff.

Resolves #116
