### PR TITLE
fix(fmt): preserve ifnull instead of converting to coalesce

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -11,8 +11,10 @@ from jarify.config import JarifyConfig
 from jarify.generator import JarifyGenerator
 from jarify.parser import (
     _extract_line_rust_fmt_placeholders,
+    _mask_ifnull,
     _mask_rust_fmt_placeholders,
     _reinsert_line_rust_fmt_placeholders,
+    _unmask_ifnull,
     _unmask_rust_fmt_placeholders,
     parse_sql,
 )
@@ -48,6 +50,7 @@ def format_sql(
     # Inline placeholders are masked with dummy identifiers that survive the AST.
     stripped_sql, line_insertions = _extract_line_rust_fmt_placeholders(sql)
     masked_sql, inline_mask = _mask_rust_fmt_placeholders(stripped_sql)
+    masked_sql = _mask_ifnull(masked_sql)
 
     try:
         trees = parse_sql(masked_sql, dialect=config.dialect)
@@ -55,6 +58,7 @@ def format_sql(
         result = _try_pivot_order_by_workaround(masked_sql, config)
         if result is not None:
             result = _unmask_rust_fmt_placeholders(result, inline_mask)
+            result = _unmask_ifnull(result)
             return _reinsert_line_rust_fmt_placeholders(result, line_insertions), warnings
         warnings.append(FormatWarning(f"could not parse SQL (formatting skipped): {exc}"))
         return sql, warnings
@@ -71,6 +75,7 @@ def format_sql(
 
     formatted = "\n;\n\n".join(formatted_parts) + ("\n;\n" if formatted_parts else "")
     formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
+    formatted = _unmask_ifnull(formatted)
     return _reinsert_line_rust_fmt_placeholders(formatted, line_insertions), warnings
 
 

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -171,6 +171,28 @@ def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[s
 
 
 # ---------------------------------------------------------------------------
+# ifnull preservation
+# ---------------------------------------------------------------------------
+# sqlglot's DuckDB dialect maps IFNULL to exp.Coalesce at parse time, losing
+# the original function name.  We mask it with a sentinel before parsing so
+# sqlglot treats it as an unknown (Anonymous) function and preserves the name,
+# then restore it after generation.
+
+_IFNULL_SENTINEL = "__jarify_ifnull"
+_IFNULL_RE = re.compile(r"\bifnull\b", re.IGNORECASE)
+
+
+def _mask_ifnull(sql: str) -> str:
+    """Replace ifnull with a sentinel so sqlglot doesn't normalize it to coalesce."""
+    return _IFNULL_RE.sub(_IFNULL_SENTINEL, sql)
+
+
+def _unmask_ifnull(sql: str) -> str:
+    """Restore ifnull from its sentinel."""
+    return sql.replace(_IFNULL_SENTINEL, "ifnull")
+
+
+# ---------------------------------------------------------------------------
 # Reserved-keyword type-cast pre-processor
 # ---------------------------------------------------------------------------
 # DuckDB allows user-defined types whose names are SQL reserved words, e.g.

--- a/tests/fixtures/select/ifnull.expected.sql
+++ b/tests/fixtures/select/ifnull.expected.sql
@@ -1,0 +1,5 @@
+SELECT
+   ifnull(a, b) AS x
+  ,ifnull(c, 0) AS y
+FROM t
+;

--- a/tests/fixtures/select/ifnull.input.sql
+++ b/tests/fixtures/select/ifnull.input.sql
@@ -1,0 +1,2 @@
+SELECT IFNULL(a, b) AS x, ifnull(c, 0) AS y
+FROM t


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `ifnull(foo, bar)` is now preserved through `jarify fmt` instead of being converted to `coalesce(foo, bar)`
- Adds a pre-format mask/post-format unmask in `formatter.py`, following the same pattern used for Rust format-string placeholders and reserved-keyword cast types
- Lint is unaffected (it does not use the formatter pipeline)

## Root cause

sqlglot's DuckDB dialect maps `IFNULL` → `exp.Coalesce` at parse time, discarding the original function name. The fix replaces `ifnull` with a sentinel identifier (`__jarify_ifnull`) before handing SQL to sqlglot. sqlglot then treats it as an unknown (`Anonymous`) function and passes it through unchanged; the post-format step restores it to `ifnull`. `IFNULL` in any case is normalised to lowercase `ifnull` on output.

## Test plan

- [ ] `tests/fixtures/select/ifnull` fixture covers uppercase `IFNULL` and lowercase `ifnull` inputs, both preserved as `ifnull` in output
- [ ] Fixture idempotency test confirms a second format pass is a no-op
- [ ] `mise run check` passes (167 tests, lint clean)

Resolves #119
