### PR TITLE
fix(fmt): convert 2-argument coalesce to ifnull

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -714,6 +714,18 @@ class JarifyGenerator(DuckDB.Generator):
         return self.func("list_contains", expression.this, expression.expression)
 
     # ------------------------------------------------------------------
+    # ifnull: prefer ifnull(a, b) over coalesce(a, b) for 2-arg case.
+    # 3+ args have no ifnull equivalent so coalesce is kept as-is.
+    # Idempotent: formatted ifnull(...) re-enters as exp.Anonymous (masked
+    # by the ifnull pre-processor in formatter.py), never hitting this path.
+    # ------------------------------------------------------------------
+
+    def coalesce_sql(self, expression: exp.Coalesce) -> str:
+        if len(expression.expressions) == 1:
+            return self.func("ifnull", expression.this, expression.expressions[0])
+        return self.func("coalesce", expression.this, *expression.expressions)
+
+    # ------------------------------------------------------------------
     # Cast: prefer :: shorthand over CAST()
     # ------------------------------------------------------------------
 

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -178,7 +178,9 @@ def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[s
 # sqlglot treats it as an unknown (Anonymous) function and preserves the name,
 # then restore it after generation.
 
-_IFNULL_SENTINEL = "__jarify_ifnull"
+# Sentinel must be the same length as "ifnull" (6 chars) so that AS-column
+# alignment computed during generation is not thrown off before the unmask.
+_IFNULL_SENTINEL = "_ifnl_"
 _IFNULL_RE = re.compile(r"\bifnull\b", re.IGNORECASE)
 
 

--- a/tests/fixtures/duckdb/reserved_keyword_type_cast.expected.sql
+++ b/tests/fixtures/duckdb/reserved_keyword_type_cast.expected.sql
@@ -3,7 +3,7 @@ SELECT
     WHEN 'a'
     THEN (
        y
-      ,array_transform(coalesce(z, []::filter[]), f -> (
+      ,array_transform(ifnull(z, []::filter[]), f -> (
          f.a
         ,f.b
       )::s)
@@ -11,7 +11,7 @@ SELECT
     WHEN 'b'
     THEN (
        y
-      ,array_transform(coalesce(z, []::filter[]), f -> (
+      ,array_transform(ifnull(z, []::filter[]), f -> (
          f.a
         ,f.b
       )::s)

--- a/tests/fixtures/select/coalesce_to_ifnull.expected.sql
+++ b/tests/fixtures/select/coalesce_to_ifnull.expected.sql
@@ -1,0 +1,6 @@
+SELECT
+   ifnull(a, b)      AS two_arg
+  ,ifnull(c, d)      AS two_arg_upper
+  ,coalesce(a, b, c) AS three_arg
+FROM t
+;

--- a/tests/fixtures/select/coalesce_to_ifnull.input.sql
+++ b/tests/fixtures/select/coalesce_to_ifnull.input.sql
@@ -1,0 +1,5 @@
+SELECT
+   coalesce(a, b)    AS two_arg
+  ,COALESCE(c, d)    AS two_arg_upper
+  ,coalesce(a, b, c) AS three_arg
+FROM t


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `coalesce(a, b)` (2-argument form) is now normalised to `ifnull(a, b)` by the formatter; 3+ arg coalesce is unchanged
- `ifnull` already round-trips correctly since #119; this closes the remaining gap for explicitly written `coalesce`
- Tightens the `ifnull` sentinel in `parser.py` to 6 chars (`_ifnl_`, same length as `ifnull`) to preserve AS-column alignment across the mask/unmask cycle — this was an idempotency bug discovered during implementation

## How it works

`exp.Coalesce` is not in DuckDB's `TRANSFORMS` dict and has no existing `coalesce_sql` method, so a new override dispatches cleanly. The `_ifnl_` sentinel fix is a correctness improvement to the approach introduced in #119.

## Test plan

- [ ] `coalesce_to_ifnull` fixture: 2-arg `coalesce` and `COALESCE` → `ifnull`; 3-arg `coalesce` preserved
- [ ] `reserved_keyword_type_cast` fixture updated: `coalesce(z, []::filter[])` → `ifnull(z, []::filter[])`
- [ ] Idempotency test passes for all fixtures (was failing before sentinel length fix)
- [ ] 168 tests pass, lint clean

Resolves #123
