### PR TITLE
fix(fmt): keep WHEN/THEN inline and suppress connector expansion in CASE branches

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -447,6 +447,54 @@ class JarifyGenerator(DuckDB.Generator):
             terms.append(self.sql(node))
 
     # ------------------------------------------------------------------
+    # CASE: keep WHEN/THEN on one line; align THEN across branches;
+    # compact THEN/ELSE values so OR/AND chains don't expand.
+    # ------------------------------------------------------------------
+
+    def case_sql(self, expression: exp.Case) -> str:
+        this = self.sql(expression, "this")
+
+        when_parts: list[str] = []
+        then_parts: list[str] = []
+        for e in expression.args["ifs"]:
+            wp = self.sql(e, "this")
+            true_expr = e.args.get("true")
+            if self.pretty and true_expr is not None:
+                compact = self._compact_sql(true_expr)
+                tp = compact if not self.too_wide([f"WHEN {wp} THEN {compact}"]) else self.sql(e, "true")
+            else:
+                tp = self.sql(e, "true")
+            when_parts.append(wp)
+            then_parts.append(tp)
+
+        default_expr = expression.args.get("default")
+        default_sql: str | None = None
+        if default_expr is not None:
+            if self.pretty:
+                compact = self._compact_sql(default_expr)
+                default_sql = compact if not self.too_wide([f"ELSE {compact}"]) else self.sql(expression, "default")
+            else:
+                default_sql = self.sql(expression, "default")
+
+        def _build(align: bool) -> list[str]:
+            max_w = max((len(w) for w in when_parts), default=0) if align else 0
+            stmts = [f"CASE {this}" if this else "CASE"]
+            for wp, tp in zip(when_parts, then_parts, strict=True):
+                stmts.append(f"WHEN {wp.ljust(max_w)} THEN {tp}")
+            if default_sql is not None:
+                stmts.append(f"ELSE {default_sql}")
+            stmts.append("END")
+            return stmts
+
+        compact_stmts = _build(align=False)
+        if not (self.pretty and self.too_wide(compact_stmts)):
+            return " ".join(compact_stmts)
+
+        # Multi-line: align THEN when all branches have single-line THEN values
+        align = len(when_parts) >= 2 and all("\n" not in tp for tp in then_parts)
+        return self.indent("\n".join(_build(align=align)), skip_first=True, skip_last=True)
+
+    # ------------------------------------------------------------------
     # WHERE / HAVING: first condition inline, AND/OR right-justified
     # ------------------------------------------------------------------
 

--- a/tests/fixtures/duckdb/reserved_keyword_type_cast.expected.sql
+++ b/tests/fixtures/duckdb/reserved_keyword_type_cast.expected.sql
@@ -1,21 +1,7 @@
 SELECT
    CASE x
-    WHEN 'a'
-    THEN (
-       y
-      ,array_transform(ifnull(z, []::filter[]), f -> (
-         f.a
-        ,f.b
-      )::s)
-    )::mystruct::json
-    WHEN 'b'
-    THEN (
-       y
-      ,array_transform(ifnull(z, []::filter[]), f -> (
-         f.a
-        ,f.b
-      )::s)
-    )::mystruct::json
+    WHEN 'a' THEN (y, array_transform(ifnull(z, []::filter[]), f -> (f.a, f.b)::s))::mystruct::json
+    WHEN 'b' THEN (y, array_transform(ifnull(z, []::filter[]), f -> (f.a, f.b)::s))::mystruct::json
   END AS result
 FROM t
 ;

--- a/tests/fixtures/select/case_when_inline.expected.sql
+++ b/tests/fixtures/select/case_when_inline.expected.sql
@@ -1,0 +1,23 @@
+/* simple searched case: short THEN values stay on one line */
+SELECT
+   CASE status WHEN 'active' THEN true WHEN 'inactive' THEN false ELSE NULL END AS is_active
+FROM accounts
+;
+
+/* simple searched case: OR connectors in THEN stay compact */
+SELECT
+   CASE _operator
+    WHEN 'equal_to'                 THEN _actual = _target
+    WHEN 'greater_than'             THEN (_target <= 0) OR (_actual > _target)
+    WHEN 'greater_than_or_equal_to' THEN (_target <= 0) OR (_actual >= _target)
+    WHEN 'less_than'                THEN _actual < _target
+    WHEN 'less_than_or_equal_to'    THEN _actual <= _target
+  END AS result
+FROM t
+;
+
+/* general case expression: short THEN values stay on one line */
+SELECT
+   CASE WHEN x > 0 THEN 'positive' WHEN x < 0 THEN 'negative' ELSE 'zero' END AS sign
+FROM t
+;

--- a/tests/fixtures/select/case_when_inline.input.sql
+++ b/tests/fixtures/select/case_when_inline.input.sql
@@ -1,0 +1,31 @@
+-- simple searched case: short THEN values stay on one line
+SELECT
+  CASE status
+    WHEN 'active' THEN true
+    WHEN 'inactive' THEN false
+    ELSE NULL
+  END AS is_active
+FROM accounts
+;
+
+-- simple searched case: OR connectors in THEN stay compact
+SELECT
+  CASE _operator
+    WHEN 'equal_to'                 THEN _actual = _target
+    WHEN 'greater_than'             THEN (_target <= 0) OR (_actual > _target)
+    WHEN 'greater_than_or_equal_to' THEN (_target <= 0) OR (_actual >= _target)
+    WHEN 'less_than'                THEN _actual < _target
+    WHEN 'less_than_or_equal_to'    THEN _actual <= _target
+  END AS result
+FROM t
+;
+
+-- general case expression: short THEN values stay on one line
+SELECT
+  CASE
+    WHEN x > 0 THEN 'positive'
+    WHEN x < 0 THEN 'negative'
+    ELSE 'zero'
+  END AS sign
+FROM t
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

Override `case_sql` in `JarifyGenerator` to fix two related formatting problems:

- **WHEN/THEN split across lines** — sqlglot's base `case_sql` builds `WHEN x` and `THEN y` as separate entries and joins them with `\n` when the total character count exceeds `max_text_width`. The override combines each branch into a single `WHEN x THEN y` entry.
- **OR/AND expansion inside THEN** — `connector_sql` unconditionally expands `AND`/`OR` chains onto separate lines in pretty mode. THEN values are now rendered compactly when the combined `WHEN … THEN …` line fits within `max_text_width`, suppressing that expansion without affecting WHERE/HAVING clauses.
- **THEN column alignment** — when a CASE goes multi-line and all branches have single-line THEN values, WHEN conditions are padded so `THEN` aligns at the same column across all branches.

**Before:**
```sql
CASE _operator
  WHEN 'equal_to'
  THEN _actual = _target
  WHEN 'greater_than'
  THEN (
    _target <= 0
  )
  OR (
    _actual > _target
  )
  ...
```

**After:**
```sql
CASE _operator
  WHEN 'equal_to'                 THEN _actual = _target
  WHEN 'greater_than'             THEN (_target <= 0) OR (_actual > _target)
  WHEN 'greater_than_or_equal_to' THEN (_target <= 0) OR (_actual >= _target)
  WHEN 'less_than'                THEN _actual < _target
  WHEN 'less_than_or_equal_to'    THEN _actual <= _target
END
```

Also updates `duckdb/reserved_keyword_type_cast` expected output and adds a `select/case_when_inline` fixture.

Resolves #126
