### PR TITLE
fix(release): regenerate uv.lock after version bump

### DIFF
--- a/.mise/tasks/release/prepare
+++ b/.mise/tasks/release/prepare
@@ -29,11 +29,12 @@ git config user.email "github-actions@github.com"
 git checkout -B "${branch}" origin/main
 
 sed -i "s/^version = \"${current}\"/version = \"${new_version}\"/" pyproject.toml
+uv lock
 
 # Generate CHANGELOG -- git-cliff knows the bump, tag it explicitly for consistency
 git-cliff --tag "v${new_version}" -o CHANGELOG.md
 
-git add pyproject.toml CHANGELOG.md
+git add pyproject.toml uv.lock CHANGELOG.md
 if git diff --staged --quiet; then
   echo "Release PR already up to date."
   exit 0


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Adds `uv lock` to `.mise/tasks/release/prepare` immediately after the `sed` version bump
- Includes `uv.lock` in the release commit alongside `pyproject.toml` and `CHANGELOG.md`

Without this fix, `uv.lock` recorded the previous version after each release, causing `uv run` to detect a stale lock and silently rewrite it, leaving `uv.lock` perpetually dirty in the working tree.

Resolves #122
