### PR TITLE
fix(fmt): guard FROM-first conversion behind self.pretty in select_sql

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -678,7 +678,8 @@ class JarifyGenerator(DuckDB.Generator):
                 for j in joins
             )
             if (
-                self._config.prefer_from_first
+                self.pretty
+                and self._config.prefer_from_first
                 and len(exprs) == 1
                 and isinstance(exprs[0], exp.Star)
                 and not expression.args.get("distinct")

--- a/tests/fixtures/select/case_when_from_first_subquery.expected.sql
+++ b/tests/fixtures/select/case_when_from_first_subquery.expected.sql
@@ -1,0 +1,8 @@
+/* CASE THEN values containing SELECT * FROM subqueries stay compact */
+SELECT
+   CASE _op
+    WHEN 'variants' THEN (SELECT * FROM (SELECT unnest(_variants) AS variant))
+    WHEN 'filters'  THEN (SELECT * FROM (SELECT unnest(_filters) AS filter))
+  END AS result
+FROM t
+;

--- a/tests/fixtures/select/case_when_from_first_subquery.input.sql
+++ b/tests/fixtures/select/case_when_from_first_subquery.input.sql
@@ -1,0 +1,7 @@
+-- CASE THEN values containing SELECT * FROM subqueries stay compact
+SELECT
+  CASE _op
+    WHEN 'variants' THEN (SELECT * FROM (SELECT unnest(_variants) AS variant))
+    WHEN 'filters' THEN (SELECT * FROM (SELECT unnest(_filters) AS filter))
+  END AS result
+FROM t


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Fixes a regression introduced in #127 where `_compact_sql` calls inside `case_sql` produced `SELECT FROM (...)` instead of `SELECT * FROM (...)` for FROM-first eligible subqueries
- Adds a regression fixture: CASE THEN values containing `(SELECT * FROM (SELECT ...))` must preserve `SELECT *` in compact form

## Root Cause

`_compact_sql` temporarily sets `self.pretty = False`. The FROM-first block in `select_sql` was running in this mode too. The regex that strips the `SELECT` keyword:

```python
return re.sub(r"(?m)^SELECT\n", "", sql)
```

relies on the newline that only exists in pretty mode. In non-pretty mode it never matched, so `SELECT` was left in place while `*` had already been removed by clearing the expressions list. Result: `SELECT FROM (...)` instead of `SELECT * FROM (...)`.

This affected every `_compact_sql` call that touched a `SELECT * FROM (...)` subquery — both the `from_sql` compact path (since #92) and the new `case_sql` compact path (added in #127).

## Fix

One-line guard on the FROM-first block:

```python
if (
    self.pretty   # ← new guard
    and self._config.prefer_from_first
    ...
):
```

FROM-first transformation now only fires during full pretty rendering, not inside `_compact_sql` passes.

Resolves #130
