### PR TITLE
fix(fmt): keep parenthesized expressions inline when they fit within max_line_length

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -447,6 +447,18 @@ class JarifyGenerator(DuckDB.Generator):
             terms.append(self.sql(node))
 
     # ------------------------------------------------------------------
+    # Paren: keep inline when the content fits within max_line_length
+    # ------------------------------------------------------------------
+
+    def paren_sql(self, expression: exp.Paren) -> str:
+        if not self.pretty:
+            return super().paren_sql(expression)
+        compact = self._compact_sql(expression.this)
+        if not self.too_wide([f"({compact})"]):
+            return f"({compact})"
+        return super().paren_sql(expression)
+
+    # ------------------------------------------------------------------
     # CASE: keep WHEN/THEN on one line; align THEN across branches;
     # compact THEN/ELSE values so OR/AND chains don't expand.
     # ------------------------------------------------------------------

--- a/tests/fixtures/select/paren_arithmetic.expected.sql
+++ b/tests/fixtures/select/paren_arithmetic.expected.sql
@@ -1,0 +1,4 @@
+SELECT
+   abs(_actual - _target) * ((_met::int * 2) - 1)
+FROM data
+;

--- a/tests/fixtures/select/paren_arithmetic.input.sql
+++ b/tests/fixtures/select/paren_arithmetic.input.sql
@@ -1,0 +1,1 @@
+SELECT abs(_actual - _target) * ((_met::int * 2) - 1) FROM data;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Override `paren_sql` in `JarifyGenerator` to render parenthesized expressions inline when the compact form fits within `max_line_length`
- Add fixture `select/paren_arithmetic` to prevent regression

## Problem

A well-formatted expression like `abs(_actual - _target) * ((_met::int * 2) - 1)` was being expanded to a deeply nested multi-line block because `JarifyGenerator` did not override `paren_sql`. sqlglot's base generator always expands `exp.Paren` nodes in pretty mode.

## Solution

Override `paren_sql` using the same compact-first pattern already in use by `case_sql` and `format_args`: try the inline rendering first; fall back to multi-line only when the content would exceed `max_line_length`.

## Test plan

- [x] `uv run python -m pytest tests/` — all 171 tests pass
- [x] `uv run jarify fmt tmp/example.sql` — reports `unchanged`
- [x] Idempotency test (`test_format_idempotent`) covers the new fixture automatically

Resolves #133
