### PR TITLE
fix(fmt): preserve -- line comments on SELECT column expressions

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -155,7 +155,7 @@ class JarifyGenerator(DuckDB.Generator):
                 sql = self.sql(e, comment=False)
                 if not sql:
                     continue
-                comments = self.maybe_comment("", e) if isinstance(e, exp.Expr) else ""
+                comments = self._inline_comments(e) if isinstance(e, exp.Expr) else ""
                 # First item gets one extra leading space (aligns content with ,item lines)
                 leader = " " if i == 0 else ","
                 result_sqls.append(f"{leader}{prefix}{sql}{comments}")
@@ -164,6 +164,17 @@ class JarifyGenerator(DuckDB.Generator):
 
         result_sql = "\n".join(s.rstrip() for s in result_sqls)
         return self.indent(result_sql, skip_first=skip_first, skip_last=skip_last) if indent else result_sql
+
+    def _inline_comments(self, expression: exp.Expr) -> str:
+        """Render inline comments using -- for single-line, /* */ for multi-line."""
+        if not self.comments or not expression.comments:
+            return ""
+        parts = []
+        for c in expression.comments:
+            if not c or not c.strip():
+                continue
+            parts.append(f"/*{c}*/" if "\n" in c else f"-- {c.strip()}")
+        return (" " + " ".join(parts)) if parts else ""
 
     def _compute_as_align_width(self, expressions_list: list) -> int | None:
         """Compute the column width for AS alignment in a SELECT expression list.

--- a/tests/fixtures/select/inline_comment.expected.sql
+++ b/tests/fixtures/select/inline_comment.expected.sql
@@ -1,0 +1,4 @@
+SELECT
+   foo -- example colum
+FROM data
+;

--- a/tests/fixtures/select/inline_comment.input.sql
+++ b/tests/fixtures/select/inline_comment.input.sql
@@ -1,0 +1,4 @@
+SELECT
+   foo -- example colum
+FROM data
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Replace `maybe_comment()` in `expressions()` with a local `_inline_comments()` helper that uses `--` for single-line comments and `/* */` for multi-line comments
- Add `tests/fixtures/select/inline_comment` fixture to cover the case

sqlglot strips the `--` prefix when parsing and stores only the comment text. Its native `maybe_comment()` always re-renders comments as `/* */` block syntax, permanently changing comment style on formatted SQL. The fix mirrors the pattern already used in `cte_sql()`.

## Test plan

- [ ] `mise run test` — all 172 tests pass, including `select/inline_comment`
- [ ] Verify `tmp/example.sql` is left unchanged by `mise run fmt`

Resolves #136
