### PR TITLE
fix(fmt): keep CASE WHEN conditions compact when AND chain is present

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -480,7 +480,8 @@ class JarifyGenerator(DuckDB.Generator):
         when_parts: list[str] = []
         then_parts: list[str] = []
         for e in expression.args["ifs"]:
-            wp = self.sql(e, "this")
+            wp_expr = e.args.get("this")
+            wp = self._compact_sql(wp_expr) if wp_expr is not None else self.sql(e, "this")
             true_expr = e.args.get("true")
             if self.pretty and true_expr is not None:
                 compact = self._compact_sql(true_expr)
@@ -510,8 +511,9 @@ class JarifyGenerator(DuckDB.Generator):
             return stmts
 
         compact_stmts = _build(align=False)
-        if not (self.pretty and self.too_wide(compact_stmts)):
-            return " ".join(compact_stmts)
+        compact_inline = " ".join(compact_stmts)
+        if not (self.pretty and self.too_wide([compact_inline])):
+            return compact_inline
 
         # Multi-line: align THEN when all branches have single-line THEN values
         align = len(when_parts) >= 2 and all("\n" not in tp for tp in then_parts)

--- a/tests/fixtures/select/case_when_and_condition.expected.sql
+++ b/tests/fixtures/select/case_when_and_condition.expected.sql
@@ -1,0 +1,10 @@
+/* CASE WHEN condition with AND chain stays compact (no line breaks inside WHEN) */
+SELECT
+   t.*
+  ,s.sku_set
+  ,CASE
+    WHEN s.transform IS NOT NULL AND s.transform.type = 'coverage' THEN t.quantity / s.conversion_rate
+    ELSE t.quantity
+  END AS coverage
+FROM transactions t
+;

--- a/tests/fixtures/select/case_when_and_condition.input.sql
+++ b/tests/fixtures/select/case_when_and_condition.input.sql
@@ -1,0 +1,9 @@
+-- CASE WHEN condition with AND chain stays compact (no line breaks inside WHEN)
+SELECT
+   t.*
+  ,s.sku_set
+  ,CASE
+     WHEN s.transform IS NOT NULL AND s.transform.type = 'coverage' THEN t.quantity/s.conversion_rate
+     ELSE t.quantity
+   END AS coverage
+FROM transactions t


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Render `CASE WHEN` conditions via `_compact_sql()` so AND/OR chains inside a `WHEN` clause never get internal newlines (same treatment already applied to `THEN`/`ELSE` values)
- Fix the `too_wide` check to evaluate the joined single-line string rather than individual parts — the original check let short-looking multi-line stmts through to the space-join path, producing garbled output
- Add a fixture (`select/case_when_and_condition`) covering the exact regression

## Test plan

- [ ] `mise run test` passes (172 tests, 0 failures)
- [ ] `jarify fmt tmp/example.sql` produces correct multi-line CASE output
- [ ] Re-running `jarify fmt` on the formatted file reports `unchanged` (idempotent)

Resolves #139
