### PR TITLE
fix(fmt): preserve SELECT when * EXCLUDE or * REPLACE is used

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -703,11 +703,12 @@ class JarifyGenerator(DuckDB.Generator):
                 and not j.args.get("using")
                 for j in joins
             )
+            star = exprs[0] if len(exprs) == 1 and isinstance(exprs[0], exp.Star) else None
+            plain_star = star is not None and not star.args.get("except_") and not star.args.get("replace")
             if (
                 self.pretty
                 and self._config.prefer_from_first
-                and len(exprs) == 1
-                and isinstance(exprs[0], exp.Star)
+                and plain_star
                 and not expression.args.get("distinct")
                 and only_comma_joins
             ):

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -648,6 +648,24 @@ class JarifyGenerator(DuckDB.Generator):
         return super().in_sql(expression)
 
     # ------------------------------------------------------------------
+    # Star: keep * EXCLUDE / REPLACE / RENAME inline when it fits
+    # ------------------------------------------------------------------
+
+    def star_sql(self, expression: exp.Star) -> str:
+        except_ = self.expressions(expression, key="except_", flat=True)
+        replace = self.expressions(expression, key="replace", flat=True)
+        rename = self.expressions(expression, key="rename", flat=True)
+
+        except_sql = f" {self.STAR_EXCEPT} ({except_})" if except_ else ""
+        replace_sql = f" REPLACE ({replace})" if replace else ""
+        rename_sql = f" RENAME ({rename})" if rename else ""
+
+        inline = f"*{except_sql}{replace_sql}{rename_sql}"
+        if self.pretty and not self.too_wide([inline]):
+            return inline
+        return super().star_sql(expression)
+
+    # ------------------------------------------------------------------
     # IS NOT NULL: preserve original form instead of NOT x IS NULL
     # ------------------------------------------------------------------
 
@@ -704,7 +722,9 @@ class JarifyGenerator(DuckDB.Generator):
                 for j in joins
             )
             star = exprs[0] if len(exprs) == 1 and isinstance(exprs[0], exp.Star) else None
-            plain_star = star is not None and not star.args.get("except_") and not star.args.get("replace")
+            plain_star = star is not None and not any(
+                star.args.get(k) for k in ("except_", "replace", "rename")
+            )
             if (
                 self.pretty
                 and self._config.prefer_from_first

--- a/tests/fixtures/select/from_first_star_qualified.expected.sql
+++ b/tests/fixtures/select/from_first_star_qualified.expected.sql
@@ -1,12 +1,15 @@
 SELECT
-   *
-  EXCLUDE (sku_set_total_coverage)
+   * EXCLUDE (sku_set_total_coverage)
 FROM _ordered
 WHERE sku_set_total_coverage > 0
 ;
 
 SELECT
-   *
-  REPLACE (col + 1 AS col)
+   * REPLACE (col + 1 AS col)
+FROM _ordered
+;
+
+SELECT
+   * RENAME (old_name AS new_name)
 FROM _ordered
 ;

--- a/tests/fixtures/select/from_first_star_qualified.expected.sql
+++ b/tests/fixtures/select/from_first_star_qualified.expected.sql
@@ -1,0 +1,12 @@
+SELECT
+   *
+  EXCLUDE (sku_set_total_coverage)
+FROM _ordered
+WHERE sku_set_total_coverage > 0
+;
+
+SELECT
+   *
+  REPLACE (col + 1 AS col)
+FROM _ordered
+;

--- a/tests/fixtures/select/from_first_star_qualified.input.sql
+++ b/tests/fixtures/select/from_first_star_qualified.input.sql
@@ -1,0 +1,2 @@
+SELECT * EXCLUDE (sku_set_total_coverage) FROM _ordered WHERE sku_set_total_coverage > 0;
+SELECT * REPLACE (col + 1 AS col) FROM _ordered;

--- a/tests/fixtures/select/from_first_star_qualified.input.sql
+++ b/tests/fixtures/select/from_first_star_qualified.input.sql
@@ -1,2 +1,3 @@
 SELECT * EXCLUDE (sku_set_total_coverage) FROM _ordered WHERE sku_set_total_coverage > 0;
 SELECT * REPLACE (col + 1 AS col) FROM _ordered;
+SELECT * RENAME (old_name AS new_name) FROM _ordered;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `SELECT * EXCLUDE (...)`, `* REPLACE (...)`, and `* RENAME (...)` were incorrectly rewritten to `FROM ...`, dropping the entire select list and producing invalid SQL
- Fixed by adding a `plain_star` guard that checks `except_`, `replace`, and `rename` args on the `Star` node before applying FROM-first rewriting
- Added `star_sql` override to keep the modifier inline (`* EXCLUDE (col)`) rather than pushing it to a new line — falls back to multi-line only when the inline form exceeds `max_line_length`

## Root Cause

sqlglot parses `* EXCLUDE (col)` as `Star(except_=[...])`, which passed the existing `isinstance(star, exp.Star)` guard. The FROM-first rewrite then cleared the expression list and stripped `SELECT`, producing SQL with no columns.

## Test Coverage

Added `tests/fixtures/select/from_first_star_qualified` covering `* EXCLUDE`, `* REPLACE`, and `* RENAME` variants; existing plain-star FROM-first fixture continues to pass.

Resolves #145
