### PR TITLE
fix(fmt): preserve leading comments on their own line in SELECT columns

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -6,6 +6,7 @@ import re
 
 from sqlglot.errors import ParseError
 from sqlglot.expressions import Expression
+from sqlglot.tokens import Tokenizer as SqlglotTokenizer
 
 from jarify.config import JarifyConfig
 from jarify.generator import JarifyGenerator
@@ -65,6 +66,7 @@ def format_sql(
 
     rules = get_default_rules(config)
     generator = JarifyGenerator(config)
+    generator._leading_comment_texts = _find_leading_comment_texts(masked_sql)
     formatted_parts: list[str] = []
 
     for tree in trees:
@@ -77,6 +79,34 @@ def format_sql(
     formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
     formatted = _unmask_ifnull(formatted)
     return _reinsert_line_rust_fmt_placeholders(formatted, line_insertions), warnings
+
+
+# ---------------------------------------------------------------------------
+# Leading-comment detection
+# ---------------------------------------------------------------------------
+
+
+def _find_leading_comment_texts(sql: str) -> frozenset[str]:
+    """Return stripped texts of comments that appear on their own line before a token.
+
+    A comment is "leading" when it occupies the region between the previous
+    token's end and the current token's start in the source text.  This lets
+    the generator distinguish ``-- note\\nfoo`` (leading) from ``foo -- note``
+    (trailing) even though sqlglot stores both in the same ``node.comments``
+    list.
+    """
+    tokens = SqlglotTokenizer().tokenize(sql)
+    leading: set[str] = set()
+    for idx, tok in enumerate(tokens):
+        if not tok.comments:
+            continue
+        prev_end = tokens[idx - 1].end if idx > 0 else 0
+        before = sql[prev_end : tok.start]
+        for comment in tok.comments:
+            stripped = comment.strip()
+            if stripped and f"-- {stripped}" in before:
+                leading.add(stripped)
+    return frozenset(leading)
 
 
 # ---------------------------------------------------------------------------

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -94,6 +94,7 @@ class JarifyGenerator(DuckDB.Generator):
         self._col_name_align: int | None = None  # set during CREATE TABLE column rendering
         self._col_type_align: int | None = None  # set during CREATE TABLE column rendering
         self._join_alias_col: int | None = None  # set during FROM/JOIN block rendering
+        self._leading_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
 
     # ------------------------------------------------------------------
     # Function name casing: aggregates/window functions → UPPER, rest → lower
@@ -155,10 +156,16 @@ class JarifyGenerator(DuckDB.Generator):
                 sql = self.sql(e, comment=False)
                 if not sql:
                     continue
-                comments = self._inline_comments(e) if isinstance(e, exp.Expr) else ""
-                # First item gets one extra leading space (aligns content with ,item lines)
                 leader = " " if i == 0 else ","
-                result_sqls.append(f"{leader}{prefix}{sql}{comments}")
+                if isinstance(e, exp.Expr) and e.comments and self._leading_comment_texts:
+                    lead = [c for c in e.comments if c.strip() in self._leading_comment_texts]
+                    trail = [c for c in e.comments if c.strip() not in self._leading_comment_texts]
+                    for c in lead:
+                        result_sqls.append(f" {prefix}-- {c.strip()}")
+                    inline = self._render_comments(trail)
+                else:
+                    inline = self._inline_comments(e) if isinstance(e, exp.Expr) else ""
+                result_sqls.append(f"{leader}{prefix}{sql}{inline}")
         finally:
             self._as_align_width = saved_align
 
@@ -169,8 +176,13 @@ class JarifyGenerator(DuckDB.Generator):
         """Render inline comments using -- for single-line, /* */ for multi-line."""
         if not self.comments or not expression.comments:
             return ""
+        return self._render_comments(expression.comments)
+
+    def _render_comments(self, comments: list[str]) -> str:
+        if not self.comments or not comments:
+            return ""
         parts = []
-        for c in expression.comments:
+        for c in comments:
             if not c or not c.strip():
                 continue
             parts.append(f"/*{c}*/" if "\n" in c else f"-- {c.strip()}")

--- a/tests/fixtures/select/leading_comment.expected.sql
+++ b/tests/fixtures/select/leading_comment.expected.sql
@@ -1,0 +1,5 @@
+SELECT
+   -- example comment
+   foo
+FROM data
+;

--- a/tests/fixtures/select/leading_comment.input.sql
+++ b/tests/fixtures/select/leading_comment.input.sql
@@ -1,0 +1,5 @@
+SELECT
+   -- example comment
+   foo
+FROM data
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `sqlglot` stores both leading (`-- note\nfoo`) and trailing (`foo -- note`) comments in the same `node.comments` list with no positional flag — the generator previously rendered all of them as trailing inline comments
- Before parsing, tokenise the SQL to find comments that occupy the region between the previous token's end and the current token's start; those are leading comments
- The generator now renders leading comments on their own line before the column expression, leaving trailing comments inline as before

Resolves #148
