### PR TITLE
fix(fmt): use -- for single-line comments instead of /* */ everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ uv sync --all-groups
 | Run both | `mise run check` |
 | Format source | `mise run fmt` |
 
-Always run `mise run check` before committing and ensure all tests pass.
+**Always run `mise run check` before committing** — this runs both lint (`ruff check`) and tests. Never push without a clean check. CI will fail if you do.
 
 ## Adding or changing a rule
 

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -104,6 +104,28 @@ class JarifyGenerator(DuckDB.Generator):
         return name.upper() if name.lower() in self._UPPERCASE_FUNCS else name.lower()
 
     # ------------------------------------------------------------------
+    # Comment rendering: use -- for single-line, /* */ for multi-line
+    # ------------------------------------------------------------------
+
+    def maybe_comment(
+        self,
+        sql: str,
+        expression: exp.Expr | None = None,
+        comments: list[str] | None = None,
+        separated: bool = False,
+    ) -> str:
+        effective = ((expression.comments if expression else None) if comments is None else comments) if self.comments else None
+        if not effective or (expression is not None and isinstance(expression, self.EXCLUDE_COMMENTS)):
+            return sql
+        rendered = self._render_comments(effective)
+        if not rendered:
+            return sql
+        if separated or isinstance(expression, self.WITH_SEPARATED_COMMENTS):
+            sep = self.sep()
+            return f"{sep}{rendered}{sql}" if not sql or sql[0].isspace() else f"{rendered}{sep}{sql}"
+        return f"{sql}{rendered}"
+
+    # ------------------------------------------------------------------
     # Leading-comma style: ,col  (comma at pad, content at pad+1)
     # ------------------------------------------------------------------
 

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -114,7 +114,9 @@ class JarifyGenerator(DuckDB.Generator):
         comments: list[str] | None = None,
         separated: bool = False,
     ) -> str:
-        effective = ((expression.comments if expression else None) if comments is None else comments) if self.comments else None
+        if comments is None:
+            comments = expression.comments if expression else None
+        effective = comments if self.comments else None
         if not effective or (expression is not None and isinstance(expression, self.EXCLUDE_COMMENTS)):
             return sql
         rendered = self._render_comments(effective)

--- a/tests/fixtures/select/case_when_and_condition.expected.sql
+++ b/tests/fixtures/select/case_when_and_condition.expected.sql
@@ -1,4 +1,4 @@
-/* CASE WHEN condition with AND chain stays compact (no line breaks inside WHEN) */
+-- CASE WHEN condition with AND chain stays compact (no line breaks inside WHEN)
 SELECT
    t.*
   ,s.sku_set

--- a/tests/fixtures/select/case_when_from_first_subquery.expected.sql
+++ b/tests/fixtures/select/case_when_from_first_subquery.expected.sql
@@ -1,4 +1,4 @@
-/* CASE THEN values containing SELECT * FROM subqueries stay compact */
+-- CASE THEN values containing SELECT * FROM subqueries stay compact
 SELECT
    CASE _op
     WHEN 'variants' THEN (SELECT * FROM (SELECT unnest(_variants) AS variant))

--- a/tests/fixtures/select/case_when_inline.expected.sql
+++ b/tests/fixtures/select/case_when_inline.expected.sql
@@ -1,10 +1,10 @@
-/* simple searched case: short THEN values stay on one line */
+-- simple searched case: short THEN values stay on one line
 SELECT
    CASE status WHEN 'active' THEN true WHEN 'inactive' THEN false ELSE NULL END AS is_active
 FROM accounts
 ;
 
-/* simple searched case: OR connectors in THEN stay compact */
+-- simple searched case: OR connectors in THEN stay compact
 SELECT
    CASE _operator
     WHEN 'equal_to'                 THEN _actual = _target
@@ -16,7 +16,7 @@ SELECT
 FROM t
 ;
 
-/* general case expression: short THEN values stay on one line */
+-- general case expression: short THEN values stay on one line
 SELECT
    CASE WHEN x > 0 THEN 'positive' WHEN x < 0 THEN 'negative' ELSE 'zero' END AS sign
 FROM t


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- sqlglot's `maybe_comment()` always wraps comments in `/* */` block syntax — jarify only intercepted this for SELECT column lists via `expressions()`; WHERE conditions, HAVING, JOIN ON, and statement-level comments all fell through to the sqlglot default
- Override `maybe_comment()` in `JarifyGenerator` to delegate to `_render_comments()`, which already emits `--` for single-line and `/* */` only for multi-line comments
- Update three `case_when` fixtures whose expected output previously captured the now-corrected `/* */` form for single-line statement-level comments

Resolves #154
