### PR TITLE
fix(fmt): keep short OR/AND conditions inline in WHERE/HAVING when they fit

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -664,6 +664,19 @@ class JarifyGenerator(DuckDB.Generator):
             this = self.sql(expression, "this")
             return f"{self.seg(keyword)} {this}"
 
+        # For a flat same-type connector chain (pure OR or pure AND, no mixing),
+        # try compact first — mirrors paren_sql's inline-if-fits logic.
+        # Mixed AND/OR chains and IN-subquery expressions keep their expanded form.
+        this = expression.this
+        if isinstance(this, exp.Connector):
+            terms_temp: list[str] = []
+            ops_list: list[str] = []
+            self._flatten_connector(this, terms_temp, ops_list)
+            if len(set(ops_list)) <= 1:
+                compact = self._compact_sql(this)
+                if not self.too_wide([f"{keyword} {compact}"]):
+                    return self.seg(f"{keyword} {compact}")
+
         condition_sql = self.sql(expression, "this")
         lines = condition_sql.split("\n")
 
@@ -788,9 +801,7 @@ class JarifyGenerator(DuckDB.Generator):
                 for j in joins
             )
             star = exprs[0] if len(exprs) == 1 and isinstance(exprs[0], exp.Star) else None
-            plain_star = star is not None and not any(
-                star.args.get(k) for k in ("except_", "replace", "rename")
-            )
+            plain_star = star is not None and not any(star.args.get(k) for k in ("except_", "replace", "rename"))
             if (
                 self.pretty
                 and self._config.prefer_from_first

--- a/tests/fixtures/select/where_or_inline.expected.sql
+++ b/tests/fixtures/select/where_or_inline.expected.sql
@@ -1,0 +1,5 @@
+SELECT
+   sku_key
+FROM sku_catalog
+WHERE supersedes IS NULL OR length(supersedes) = 0
+;

--- a/tests/fixtures/select/where_or_inline.input.sql
+++ b/tests/fixtures/select/where_or_inline.input.sql
@@ -1,0 +1,5 @@
+SELECT
+   sku_key
+FROM sku_catalog
+WHERE supersedes IS NULL OR len(supersedes) = 0
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `WHERE`/`HAVING` clauses with a pure same-type connector chain (all `OR` or all `AND`) now stay on one line when the result fits within `max_line_length`
- Mixed `AND`/`OR` chains and `IN (subquery)` expressions are intentionally excluded and keep their expanded multi-line form
- Adds fixture `select/where_or_inline` to cover the reported case

## Root cause

`connector_sql` always inserts newlines in pretty mode, so `WHERE a IS NULL OR b = 0` became two lines even though it fit on one. The parenthesized form `WHERE (a IS NULL OR b = 0)` avoided this because `paren_sql` tries compact first. `_inline_clause_sql` now applies the same inline-if-fits logic for flat same-type chains.

Resolves #157
