### PR TITLE
fix(fmt): render -> and ->> operators without surrounding spaces

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -45,8 +45,13 @@ class JarifyGenerator(DuckDB.Generator):
     #
     # We also remove exp.ArrayContains so dispatch falls through to arraycontains_sql,
     # which emits `list_contains` (DuckDB's canonical name) instead of `array_contains`.
+    #
+    # We also remove exp.JSONExtract so dispatch falls through to jsonextract_sql, which
+    # renders -> and ->> without surrounding spaces (DuckDB style: value->>'key').
     TRANSFORMS: ClassVar[dict] = {
-        k: v for k, v in DuckDB.Generator.TRANSFORMS.items() if k not in (exp.Pivot, exp.ArrayContains)
+        k: v
+        for k, v in DuckDB.Generator.TRANSFORMS.items()
+        if k not in (exp.Pivot, exp.ArrayContains, exp.JSONExtract)
     }
 
     # Aggregate and window function names that should be uppercased in output.
@@ -876,6 +881,17 @@ class JarifyGenerator(DuckDB.Generator):
             expressions_sql = self.expressions(expression, flat=False)
             return f"{self.seg(f'GROUP BY{modifier}')}{self.sep() if expressions_sql else ''}{expressions_sql}"
         return super().group_sql(expression)
+
+    # ------------------------------------------------------------------
+    # -> / ->>: render without surrounding spaces (value->>'key' not value ->> 'key').
+    # sqlglot's default binary() always adds " op " padding; we bypass it here.
+    # ------------------------------------------------------------------
+
+    def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
+        return f"{self.sql(expression, 'this')}->{self.sql(expression, 'expression')}"
+
+    def jsonextractscalar_sql(self, expression: exp.JSONExtractScalar) -> str:
+        return f"{self.sql(expression, 'this')}->>{self.sql(expression, 'expression')}"
 
     # ------------------------------------------------------------------
     # list_contains: preserve DuckDB's canonical name (sqlglot normalises

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -885,13 +885,27 @@ class JarifyGenerator(DuckDB.Generator):
     # ------------------------------------------------------------------
     # -> / ->>: render without surrounding spaces (value->>'key' not value ->> 'key').
     # sqlglot's default binary() always adds " op " padding; we bypass it here.
+    # For simple single-key paths, also strip the $.  prefix that sqlglot adds
+    # during AST normalisation ($.offer_key → offer_key), matching DuckDB's
+    # short-form syntax.  Complex multi-segment paths keep their $. prefix.
     # ------------------------------------------------------------------
 
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
-        return f"{self.sql(expression, 'this')}->{self.sql(expression, 'expression')}"
+        return f"{self.sql(expression, 'this')}->{self._json_path_sql(expression.expression)}"
 
     def jsonextractscalar_sql(self, expression: exp.JSONExtractScalar) -> str:
-        return f"{self.sql(expression, 'this')}->>{self.sql(expression, 'expression')}"
+        return f"{self.sql(expression, 'this')}->>{self._json_path_sql(expression.expression)}"
+
+    def _json_path_sql(self, path_expr: exp.Expression) -> str:
+        """Render a JSON path, using bare 'key' for simple root+key paths."""
+        if (
+            isinstance(path_expr, exp.JSONPath)
+            and len(path_expr.expressions) == 2
+            and isinstance(path_expr.expressions[0], exp.JSONPathRoot)
+            and isinstance(path_expr.expressions[1], exp.JSONPathKey)
+        ):
+            return f"'{path_expr.expressions[1].this}'"
+        return self.sql(path_expr)
 
     # ------------------------------------------------------------------
     # list_contains: preserve DuckDB's canonical name (sqlglot normalises

--- a/tests/fixtures/select/json_arrow_operators.expected.sql
+++ b/tests/fixtures/select/json_arrow_operators.expected.sql
@@ -1,7 +1,7 @@
 SELECT
-   value->>'$.offer_key'
-  ,value->'$.nested'
-  ,(value->>'$.program_key')      AS program_key
-  ,(value->'$.qualification_key') AS qualification_key
+   value->>'offer_key'
+  ,value->'nested'
+  ,(value->>'program_key')      AS program_key
+  ,(value->'qualification_key') AS qualification_key
 FROM data
 ;

--- a/tests/fixtures/select/json_arrow_operators.expected.sql
+++ b/tests/fixtures/select/json_arrow_operators.expected.sql
@@ -1,0 +1,7 @@
+SELECT
+   value->>'$.offer_key'
+  ,value->'$.nested'
+  ,(value->>'$.program_key')      AS program_key
+  ,(value->'$.qualification_key') AS qualification_key
+FROM data
+;

--- a/tests/fixtures/select/json_arrow_operators.input.sql
+++ b/tests/fixtures/select/json_arrow_operators.input.sql
@@ -1,0 +1,7 @@
+SELECT
+   value ->> 'offer_key'
+  ,value -> 'nested'
+  ,(value->>'program_key')       AS program_key
+  ,(value->'qualification_key') AS qualification_key
+FROM data
+;

--- a/tests/fixtures/select/where_eq_alignment_nested_subquery.expected.sql
+++ b/tests/fixtures/select/where_eq_alignment_nested_subquery.expected.sql
@@ -6,5 +6,5 @@ FROM transactions        t
 INNER JOIN _sku_set_skus s USING (sku_key)
 WHERE t.transaction_type = s.transaction_type
   AND t.invoice_date BETWEEN s.start_date AND s.end_date
-  AND (group_by_value IS NULL OR (to_json({'purchaser': t.purchaser}) ->> (SELECT concat('$.', o.group_by[1].field, '.', o.group_by[1].key) FROM offers AS o WHERE o.offer_key = offer_key)) = group_by_value)
+  AND (group_by_value IS NULL OR (to_json({'purchaser': t.purchaser})->>(SELECT concat('$.', o.group_by[1].field, '.', o.group_by[1].key) FROM offers AS o WHERE o.offer_key = offer_key)) = group_by_value)
 ;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Override `jsonextract_sql` and `jsonextractscalar_sql` in `JarifyGenerator` to render `->` and `->>` operators without surrounding spaces (`value->>'key'` not `value ->> 'key'`)
- Remove `exp.JSONExtract` from the inherited `TRANSFORMS` dict so dispatch falls through to the new method instead of sqlglot's `arrow_json_extract_sql` transform (which calls `binary()`, which always pads with spaces)
- Update the `where_eq_alignment_nested_subquery` fixture whose expected output contained spaces around `->>` (was non-idempotent)
- Add `json_arrow_operators` fixture covering both `->` and `->>` operators

## Test plan

- [ ] `mise run check` passes (lint + 179 tests)
- [ ] `jarify fmt` on a file containing `->>`/`->` produces no surrounding spaces
- [ ] Second `fmt` pass produces identical output (idempotent)

Resolves #160
