### PR TITLE
fix(fmt): preserve AS alignment when SELECT contains Rust format placeholder strings

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -228,12 +228,19 @@ class JarifyGenerator(DuckDB.Generator):
             return None
 
         col_widths: list[int] = []
-        for a in aliased:
-            col_sql = self.sql(a.this)
-            if "\n" in col_sql:
-                # Multi-line expression — skip alignment for the whole SELECT
-                return None
-            col_widths.append(len(col_sql))
+        for e in expressions_list:
+            if isinstance(e, exp.Alias):
+                col_sql = self.sql(e.this)
+                if "\n" in col_sql:
+                    # Multi-line aliased expression — skip alignment for the whole SELECT
+                    return None
+                col_widths.append(len(col_sql))
+            else:
+                # Non-aliased columns count toward the alignment width so AS
+                # keywords clear the longest expression in the list.
+                col_sql = self.sql(e)
+                if "\n" not in col_sql:
+                    col_widths.append(len(col_sql))
 
         return max(col_widths)
 

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -50,7 +50,14 @@ def _mask_rust_fmt_placeholders(sql: str) -> tuple[str, dict[str, str]]:
     def _next_marker(placeholder: str, *, inline: bool) -> str:
         n = seq[0]
         seq[0] += 1
-        marker = f"__jrfp{n}__" if inline else f"/* __J_RFP_{n}__ */"
+        if inline:
+            base = f"__jrfp{n}__"
+            # Pad to original length so string-literal widths are preserved
+            # during AS-alignment computation (see _compute_as_align_width).
+            extra = max(0, len(placeholder) - len(base))
+            marker = base + "_" * extra
+        else:
+            marker = f"/* __J_RFP_{n}__ */"
         mapping[marker] = placeholder
         return marker
 

--- a/tests/fixtures/select/alias_alignment_rust_fmt_placeholder.expected.sql
+++ b/tests/fixtures/select/alias_alignment_rust_fmt_placeholder.expected.sql
@@ -1,10 +1,10 @@
 SELECT
-   '{request_id}'        AS request_id
-  ,wp.invoice_date::date AS invoice_date
-  ,wp.sku_key            AS provided_sku_key
-  ,wp.resolved_sku_key   AS sku_key
+   '{request_id}'               AS request_id
+  ,wp.invoice_date::date        AS invoice_date
+  ,wp.sku_key                   AS provided_sku_key
+  ,wp.resolved_sku_key          AS sku_key
   ,wp.program_redemption_amount
-  ,wp.amount::double     AS provided_amount
-  ,wp.quantity::double   AS quantity
+  ,wp.amount::double            AS provided_amount
+  ,wp.quantity::double          AS quantity
 FROM _with_prices wp
 ;

--- a/tests/fixtures/select/alias_alignment_rust_fmt_placeholder.expected.sql
+++ b/tests/fixtures/select/alias_alignment_rust_fmt_placeholder.expected.sql
@@ -1,0 +1,10 @@
+SELECT
+   '{request_id}'        AS request_id
+  ,wp.invoice_date::date AS invoice_date
+  ,wp.sku_key            AS provided_sku_key
+  ,wp.resolved_sku_key   AS sku_key
+  ,wp.program_redemption_amount
+  ,wp.amount::double     AS provided_amount
+  ,wp.quantity::double   AS quantity
+FROM _with_prices wp
+;

--- a/tests/fixtures/select/alias_alignment_rust_fmt_placeholder.input.sql
+++ b/tests/fixtures/select/alias_alignment_rust_fmt_placeholder.input.sql
@@ -1,0 +1,10 @@
+SELECT
+   '{request_id}' AS request_id
+  ,wp.invoice_date::date AS invoice_date
+  ,wp.sku_key AS provided_sku_key
+  ,wp.resolved_sku_key AS sku_key
+  ,wp.program_redemption_amount
+  ,wp.amount::double AS provided_amount
+  ,wp.quantity::double AS quantity
+FROM _with_prices wp
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

Two bugs fixed, both affecting `AS` alignment in `SELECT` lists:

**Bug 1 — Rust format placeholder strings (`parser.py`)**
- Inline placeholders like `{request_id}` were masked to `__jrfpN__` (shorter) before parsing, so `_compute_as_align_width` saw the masked literal `'__jrfp0__'` (11 chars) instead of the original `'{request_id}'` (14 chars)
- After the originals were restored, `AS` keywords were 3 columns too far right
- Fix: pad the inline marker with trailing underscores to match the original placeholder length

**Bug 2 — Non-aliased columns not considered (`generator.py`)**
- `_compute_as_align_width` only scanned aliased expressions, so a bare column like `wp.program_redemption_amount` was ignored even when it was the longest item in the `SELECT` list
- Fix: include all expressions in the max-width scan; non-aliased single-line ones contribute to the width but never abort alignment

## Test plan

- [ ] New fixture `alias_alignment_rust_fmt_placeholder` verifies `AS` keywords align to `wp.program_redemption_amount` (the longest non-aliased column) when the list also contains a Rust format placeholder string literal
- [ ] `mise run check` passes (180 tests, lint clean)

Resolves #163
