### PR TITLE
fix(fmt): handle whole-line placeholder as CTAS body

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -11,10 +11,12 @@ from sqlglot.tokens import Tokenizer as SqlglotTokenizer
 from jarify.config import JarifyConfig
 from jarify.generator import JarifyGenerator
 from jarify.parser import (
+    _extract_ctas_body_placeholders,
     _extract_line_rust_fmt_placeholders,
     _mask_ifnull,
     _mask_rust_fmt_placeholders,
     _reinsert_line_rust_fmt_placeholders,
+    _restore_ctas_body_placeholders,
     _unmask_ifnull,
     _unmask_rust_fmt_placeholders,
     parse_sql,
@@ -46,10 +48,15 @@ def format_sql(
     config = config or JarifyConfig()
     warnings: list[FormatWarning] = []
 
+    # Pre-process: replace whole-line placeholders used as CTAS bodies (those
+    # following a line that ends with AS) with a dummy SELECT so sqlglot
+    # receives a complete, parseable CTAS and does not silently drop the AS.
+    processed_sql, ctas_body_map = _extract_ctas_body_placeholders(sql)
+
     # Strip whole-line Rust format placeholders so sqlglot never sees them.
     # They are re-inserted verbatim after formatting using the recorded anchors.
     # Inline placeholders are masked with dummy identifiers that survive the AST.
-    stripped_sql, line_insertions = _extract_line_rust_fmt_placeholders(sql)
+    stripped_sql, line_insertions = _extract_line_rust_fmt_placeholders(processed_sql)
     masked_sql, inline_mask = _mask_rust_fmt_placeholders(stripped_sql)
     masked_sql = _mask_ifnull(masked_sql)
 
@@ -60,7 +67,8 @@ def format_sql(
         if result is not None:
             result = _unmask_rust_fmt_placeholders(result, inline_mask)
             result = _unmask_ifnull(result)
-            return _reinsert_line_rust_fmt_placeholders(result, line_insertions), warnings
+            result = _reinsert_line_rust_fmt_placeholders(result, line_insertions)
+            return _restore_ctas_body_placeholders(result, ctas_body_map), warnings
         warnings.append(FormatWarning(f"could not parse SQL (formatting skipped): {exc}"))
         return sql, warnings
 
@@ -78,7 +86,8 @@ def format_sql(
     formatted = "\n;\n\n".join(formatted_parts) + ("\n;\n" if formatted_parts else "")
     formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
     formatted = _unmask_ifnull(formatted)
-    return _reinsert_line_rust_fmt_placeholders(formatted, line_insertions), warnings
+    result = _reinsert_line_rust_fmt_placeholders(formatted, line_insertions)
+    return _restore_ctas_body_placeholders(result, ctas_body_map), warnings
 
 
 # ---------------------------------------------------------------------------

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -31,6 +31,7 @@ DUCKDB_DIALECT = "duckdb"
 
 _RUST_FMT_RE = re.compile(r"\{[A-Za-z_]\w*\}")
 _RUST_FMT_LINE_RE = re.compile(r"^\s*\{[A-Za-z_]\w*\}\s*$")
+_AS_TRAILING_RE = re.compile(r"\bAS$", re.IGNORECASE)
 
 
 def _mask_rust_fmt_placeholders(sql: str) -> tuple[str, dict[str, str]]:
@@ -78,6 +79,64 @@ def _unmask_rust_fmt_placeholders(sql: str, mapping: dict[str, str]) -> str:
     for marker, original in mapping.items():
         sql = sql.replace(marker, original)
     return sql
+
+
+def _extract_ctas_body_placeholders(sql: str) -> tuple[str, dict[str, str]]:
+    """Replace whole-line placeholders that serve as a CTAS body with dummy markers.
+
+    A placeholder is a CTAS body when it immediately follows a line ending with
+    the keyword ``AS`` (case-insensitive).  The dummy body ``SELECT * FROM
+    __J_CTAS_BODY_N__`` lets sqlglot parse a complete, valid CTAS so neither
+    the ``AS`` keyword nor surrounding structure is dropped.
+
+    Returns ``(modified_sql, {marker: original_placeholder_line})``.  When no
+    such pattern exists the SQL is returned unchanged with an empty mapping.
+    """
+    ctas_body_map: dict[str, str] = {}
+    counter = 0
+    lines = sql.splitlines(keepends=True)
+    result: list[str] = []
+
+    for i, line in enumerate(lines):
+        if _RUST_FMT_LINE_RE.match(line):
+            # Find the previous non-blank line to check for a trailing AS.
+            prev_content = ""
+            for j in range(i - 1, -1, -1):
+                stripped = lines[j].strip()
+                if stripped:
+                    prev_content = stripped
+                    break
+            if _AS_TRAILING_RE.search(prev_content):
+                marker = f"__J_CTAS_BODY_{counter}__"
+                ctas_body_map[marker] = line.rstrip("\r\n")
+                result.append(f"SELECT * FROM {marker}\n")
+                counter += 1
+                continue
+        result.append(line)
+
+    return "".join(result), ctas_body_map
+
+
+def _restore_ctas_body_placeholders(sql: str, ctas_body_map: dict[str, str]) -> str:
+    """Restore CTAS body placeholders from their dummy markers.
+
+    Replaces the entire formatted line that contains a CTAS body marker with
+    the original placeholder text.
+    """
+    if not ctas_body_map:
+        return sql
+    lines = sql.splitlines(keepends=True)
+    result: list[str] = []
+    for line in lines:
+        replaced = False
+        for marker, original in ctas_body_map.items():
+            if marker in line:
+                result.append(original + "\n")
+                replaced = True
+                break
+        if not replaced:
+            result.append(line)
+    return "".join(result)
 
 
 def _extract_line_rust_fmt_placeholders(

--- a/tests/fixtures/templates/rust_fmt_ctas_body_placeholder.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_ctas_body_placeholder.expected.sql
@@ -1,0 +1,3 @@
+CREATE OR REPLACE TABLE {table_name} AS
+{query_body}
+;

--- a/tests/fixtures/templates/rust_fmt_ctas_body_placeholder.input.sql
+++ b/tests/fixtures/templates/rust_fmt_ctas_body_placeholder.input.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE TABLE {table_name} AS
+{query_body}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,10 +6,12 @@ import sys
 import pytest
 
 from jarify.parser import (
+    _extract_ctas_body_placeholders,
     _extract_line_rust_fmt_placeholders,
     _mask_rust_fmt_placeholders,
     _quote_reserved_cast_types,
     _reinsert_line_rust_fmt_placeholders,
+    _restore_ctas_body_placeholders,
     _unmask_rust_fmt_placeholders,
     parse_sql,
     parse_sql_lenient,
@@ -247,3 +249,50 @@ class TestExtractReinsertLinePlaceholders:
         ex_idx = lines.index("{example_filter}")
         create_idx = next(i for i, ln in enumerate(lines) if ln.startswith("CREATE TABLE"))
         assert prog_idx < ex_idx < create_idx
+
+
+class TestCtasBodyPlaceholders:
+    """_extract/_restore_ctas_body_placeholders must handle CTAS body placeholders."""
+
+    def test_ctas_body_placeholder_detected(self) -> None:
+        sql = "CREATE OR REPLACE TABLE {t} AS\n{query_body}\n"
+        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        assert len(ctas_body_map) == 1
+        assert "{query_body}" in ctas_body_map.values()
+        assert "{query_body}" not in modified
+        assert "SELECT * FROM" in modified
+
+    def test_non_ctas_placeholder_not_affected(self) -> None:
+        sql = "FROM examples\n{where_clause}\n;\n"
+        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        assert ctas_body_map == {}
+        assert modified == sql
+
+    def test_inline_placeholder_not_affected(self) -> None:
+        sql = "SELECT * FROM {table_name}\n;\n"
+        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        assert ctas_body_map == {}
+        assert modified == sql
+
+    def test_restore_replaces_marker_line(self) -> None:
+        sql = "CREATE OR REPLACE TABLE {t} AS\n{query_body}\n"
+        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        # Simulate a formatted line containing the marker
+        marker = next(iter(ctas_body_map))
+        formatted = f"CREATE OR REPLACE TABLE t AS\nFROM {marker}\n;\n"
+        restored = _restore_ctas_body_placeholders(formatted, ctas_body_map)
+        assert marker not in restored
+        assert "{query_body}" in restored
+        assert "FROM" not in restored
+
+    def test_restore_no_op_when_map_empty(self) -> None:
+        sql = "SELECT 1\n;\n"
+        assert _restore_ctas_body_placeholders(sql, {}) == sql
+
+    def test_multiple_ctas_bodies_get_unique_markers(self) -> None:
+        sql = "CREATE TABLE {t1} AS\n{body1}\n;\n\nCREATE TABLE {t2} AS\n{body2}\n"
+        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        assert len(ctas_body_map) == 2
+        assert len(set(ctas_body_map.keys())) == 2
+        assert "{body1}" in ctas_body_map.values()
+        assert "{body2}" in ctas_body_map.values()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -276,7 +276,7 @@ class TestCtasBodyPlaceholders:
 
     def test_restore_replaces_marker_line(self) -> None:
         sql = "CREATE OR REPLACE TABLE {t} AS\n{query_body}\n"
-        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        _modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
         # Simulate a formatted line containing the marker
         marker = next(iter(ctas_body_map))
         formatted = f"CREATE OR REPLACE TABLE t AS\nFROM {marker}\n;\n"
@@ -291,7 +291,7 @@ class TestCtasBodyPlaceholders:
 
     def test_multiple_ctas_bodies_get_unique_markers(self) -> None:
         sql = "CREATE TABLE {t1} AS\n{body1}\n;\n\nCREATE TABLE {t2} AS\n{body2}\n"
-        modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
+        _modified, ctas_body_map = _extract_ctas_body_placeholders(sql)
         assert len(ctas_body_map) == 2
         assert len(set(ctas_body_map.keys())) == 2
         assert "{body1}" in ctas_body_map.values()


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- Detect whole-line Rust format placeholders that are used as CTAS bodies (immediately following a line ending with `AS`) and substitute a dummy `SELECT * FROM __J_CTAS_BODY_N__` before passing to sqlglot, so sqlglot receives a complete parseable CTAS and does not silently drop the `AS` keyword
- After formatting, find the dummy body line in the output and replace it with the original placeholder — restoring both the `AS` keyword and correct semicolon placement
- Adds `_extract_ctas_body_placeholders` / `_restore_ctas_body_placeholders` in `parser.py` and wires them into `format_sql` as a pre/post pass
- Adds unit tests in `test_parser.py` and a fixture pair under `tests/fixtures/templates/`

Resolves #166

## Test plan

- [ ] `mise run test` passes (187 tests)
- [ ] `jarify fmt tmp/example.sql` produces `CREATE OR REPLACE TABLE {table_name} AS\n{query_body}\n;\n`
- [ ] Running `fmt` a second time on the output is a no-op (idempotent)
