### PR TITLE
fix(fmt): preserve between-column -- comments in SELECT lists

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -75,6 +75,7 @@ def format_sql(
     rules = get_default_rules(config)
     generator = JarifyGenerator(config)
     generator._leading_comment_texts = _find_leading_comment_texts(masked_sql)
+    generator._trailing_sep_comment_texts = _find_trailing_sep_comment_texts(masked_sql)
     formatted_parts: list[str] = []
 
     for tree in trees:
@@ -100,10 +101,16 @@ def _find_leading_comment_texts(sql: str) -> frozenset[str]:
 
     A comment is "leading" when it occupies the region between the previous
     token's end and the current token's start in the source text.  This lets
-    the generator distinguish ``-- note\\nfoo`` (leading) from ``foo -- note``
+    the generator distinguish ``-- note\nfoo`` (leading) from ``foo -- note``
     (trailing) even though sqlglot stores both in the same ``node.comments``
     list.
+
+    See also :func:`_find_trailing_sep_comment_texts` for comments that appear
+    on their own line *after* an expression but before its following comma
+    separator (e.g. between two SELECT columns).
     """
+    from sqlglot.tokens import TokenType
+
     tokens = SqlglotTokenizer().tokenize(sql)
     leading: set[str] = set()
     for idx, tok in enumerate(tokens):
@@ -111,11 +118,56 @@ def _find_leading_comment_texts(sql: str) -> frozenset[str]:
             continue
         prev_end = tokens[idx - 1].end if idx > 0 else 0
         before = sql[prev_end : tok.start]
+        prev_type = tokens[idx - 1].token_type if idx > 0 else None
+        for comment in tok.comments:
+            stripped = comment.strip()
+            if not stripped or f"-- {stripped}" not in before:
+                continue
+            # When the owning token is a comma AND the preceding token is a
+            # plain expression (not a closing paren), sqlglot's parser moves
+            # the comment to the *preceding* expression node.  That makes it
+            # trailing-sep, not leading.  Skip it here; captured by
+            # _find_trailing_sep_comment_texts instead.
+            if tok.token_type == TokenType.COMMA and prev_type != TokenType.R_PAREN:
+                continue
+            leading.add(stripped)
+    return frozenset(leading)
+
+
+def _find_trailing_sep_comment_texts(sql: str) -> frozenset[str]:
+    """Return stripped texts of comments that sit on their own line *after* an
+    expression and *before* the comma separator that follows it.
+
+    Example::
+
+        ,qualifier
+         -- this comment lives between qualifier and str_split_regex
+        ,str_split_regex(...)
+
+    sqlglot attaches such a comment to the preceding expression (``qualifier``)
+    because the comma token that follows the comment owns it at tokenise-time
+    and the parser moves it backwards.  The generator must render these after
+    the expression's line so they stay between the two columns.
+    """
+    from sqlglot.tokens import TokenType
+
+    tokens = SqlglotTokenizer().tokenize(sql)
+    trailing_sep: set[str] = set()
+    for idx, tok in enumerate(tokens):
+        if not tok.comments or tok.token_type != TokenType.COMMA:
+            continue
+        prev_type = tokens[idx - 1].token_type if idx > 0 else None
+        # Closing paren before comma = end of a body/subquery; the comment
+        # belongs to the *next* expression (e.g. a CTE name), not this rule.
+        if prev_type == TokenType.R_PAREN:
+            continue
+        prev_end = tokens[idx - 1].end if idx > 0 else 0
+        before = sql[prev_end : tok.start]
         for comment in tok.comments:
             stripped = comment.strip()
             if stripped and f"-- {stripped}" in before:
-                leading.add(stripped)
-    return frozenset(leading)
+                trailing_sep.add(stripped)
+    return frozenset(trailing_sep)
 
 
 # ---------------------------------------------------------------------------

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -204,7 +204,7 @@ class JarifyGenerator(DuckDB.Generator):
                     inline = self._render_comments(trail)
                     result_sqls.append(f"{leader}{prefix}{sql}{inline}")
                     for c in trail_sep:
-                        result_sqls.append(f" {prefix}-- {c.strip()}")
+                        result_sqls.append(f"{prefix}-- {c.strip()}")
                 else:
                     inline = self._inline_comments(e) if isinstance(e, exp.Expr) else ""
                     result_sqls.append(f"{leader}{prefix}{sql}{inline}")

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -49,9 +49,7 @@ class JarifyGenerator(DuckDB.Generator):
     # We also remove exp.JSONExtract so dispatch falls through to jsonextract_sql, which
     # renders -> and ->> without surrounding spaces (DuckDB style: value->>'key').
     TRANSFORMS: ClassVar[dict] = {
-        k: v
-        for k, v in DuckDB.Generator.TRANSFORMS.items()
-        if k not in (exp.Pivot, exp.ArrayContains, exp.JSONExtract)
+        k: v for k, v in DuckDB.Generator.TRANSFORMS.items() if k not in (exp.Pivot, exp.ArrayContains, exp.JSONExtract)
     }
 
     # Aggregate and window function names that should be uppercased in output.
@@ -100,6 +98,7 @@ class JarifyGenerator(DuckDB.Generator):
         self._col_type_align: int | None = None  # set during CREATE TABLE column rendering
         self._join_alias_col: int | None = None  # set during FROM/JOIN block rendering
         self._leading_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
+        self._trailing_sep_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
 
     # ------------------------------------------------------------------
     # Function name casing: aggregates/window functions → UPPER, rest → lower
@@ -187,15 +186,28 @@ class JarifyGenerator(DuckDB.Generator):
                 if not sql:
                     continue
                 leader = " " if i == 0 else ","
-                if isinstance(e, exp.Expr) and e.comments and self._leading_comment_texts:
+                if isinstance(e, exp.Expr) and e.comments and (
+                    self._leading_comment_texts or self._trailing_sep_comment_texts
+                ):
                     lead = [c for c in e.comments if c.strip() in self._leading_comment_texts]
-                    trail = [c for c in e.comments if c.strip() not in self._leading_comment_texts]
+                    trail_sep = [
+                        c for c in e.comments if c.strip() in self._trailing_sep_comment_texts
+                    ]
+                    trail = [
+                        c
+                        for c in e.comments
+                        if c.strip() not in self._leading_comment_texts
+                        and c.strip() not in self._trailing_sep_comment_texts
+                    ]
                     for c in lead:
                         result_sqls.append(f" {prefix}-- {c.strip()}")
                     inline = self._render_comments(trail)
+                    result_sqls.append(f"{leader}{prefix}{sql}{inline}")
+                    for c in trail_sep:
+                        result_sqls.append(f" {prefix}-- {c.strip()}")
                 else:
                     inline = self._inline_comments(e) if isinstance(e, exp.Expr) else ""
-                result_sqls.append(f"{leader}{prefix}{sql}{inline}")
+                    result_sqls.append(f"{leader}{prefix}{sql}{inline}")
         finally:
             self._as_align_width = saved_align
 

--- a/tests/fixtures/select/between_column_comment.expected.sql
+++ b/tests/fixtures/select/between_column_comment.expected.sql
@@ -2,7 +2,7 @@ SELECT
    level_key
   ,level_type
   ,qualifier
-   -- pad parentheses with spaces so they become separate tokens
+  -- pad parentheses with spaces so they become separate tokens
   ,str_split_regex(regexp_replace(qualifier, '([\(\)])', ' \1 ', 'g'), '\s+') AS parts
 FROM _qualifiers
 ;

--- a/tests/fixtures/select/between_column_comment.expected.sql
+++ b/tests/fixtures/select/between_column_comment.expected.sql
@@ -1,0 +1,8 @@
+SELECT
+   level_key
+  ,level_type
+  ,qualifier
+   -- pad parentheses with spaces so they become separate tokens
+  ,str_split_regex(regexp_replace(qualifier, '([\(\)])', ' \1 ', 'g'), '\s+') AS parts
+FROM _qualifiers
+;

--- a/tests/fixtures/select/between_column_comment.input.sql
+++ b/tests/fixtures/select/between_column_comment.input.sql
@@ -1,0 +1,8 @@
+SELECT
+   level_key
+  ,level_type
+  ,qualifier
+   -- pad parentheses with spaces so they become separate tokens
+  ,str_split_regex(regexp_replace(qualifier, '([\(\)])', ' \1 ', 'g'), '\s+') AS parts
+FROM _qualifiers
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by pi (Claude claude-opus-4-5) on behalf of @johnallen3d.

## Summary

`jarify fmt` was moving a standalone `-- comment` between two SELECT columns to the
wrong position (one column too early) and adding an extra leading space to the
comment line.

**Before (broken):**
```sql
SELECT
   level_key
  ,level_type
   -- pad parentheses with spaces so they become separate tokens
  ,qualifier
  ,str_split_regex(...) AS parts
```

**After (correct, idempotent):**
```sql
SELECT
   level_key
  ,level_type
  ,qualifier
  -- pad parentheses with spaces so they become separate tokens
  ,str_split_regex(...) AS parts
```

## Root cause

sqlglot's tokenizer attaches a between-column comment to the comma separator that
follows the preceding expression.  `_find_leading_comment_texts` in `formatter.py`
found the comment in the text region before that comma and marked it "leading".  The
generator then rendered it before the expression the comment was attached to in the
AST — one column too early.  The `" "` leader used when appending the comment to
`result_sqls` also added one extra indent space compared to the surrounding
comma-prefixed columns.

## Fix

- Added `_find_trailing_sep_comment_texts` in `formatter.py` to detect comments that
  sit on their own line **after** a plain expression and before its following comma
  separator.  CTE leading comments (where the token before the comma is `)`) are
  excluded so existing CTE comment behaviour is unchanged.
- The generator's `expressions()` method now renders trailing-sep comments on their
  own line **after** the owning expression, preserving their position between the two
  columns.
- Removed the extra `" "` leader from the trailing-sep render path so the comment
  lands at the same 2-space indent as the surrounding `  ,col` lines.
- Added `between_column_comment` fixture to cover the bug and verify idempotency.

Resolves #172
