### PR TITLE
fix(fmt): remove extra space before column list in UNNEST table aliases

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -192,13 +192,13 @@ class JarifyGenerator(DuckDB.Generator):
                 if not sql:
                     continue
                 leader = " " if i == 0 else ","
-                if isinstance(e, exp.Expr) and e.comments and (
-                    self._leading_comment_texts or self._trailing_sep_comment_texts
+                if (
+                    isinstance(e, exp.Expr)
+                    and e.comments
+                    and (self._leading_comment_texts or self._trailing_sep_comment_texts)
                 ):
                     lead = [c for c in e.comments if c.strip() in self._leading_comment_texts]
-                    trail_sep = [
-                        c for c in e.comments if c.strip() in self._trailing_sep_comment_texts
-                    ]
+                    trail_sep = [c for c in e.comments if c.strip() in self._trailing_sep_comment_texts]
                     trail = [
                         c
                         for c in e.comments
@@ -283,8 +283,7 @@ class JarifyGenerator(DuckDB.Generator):
         return f"{this_sql} AS {alias_name}"
 
     # ------------------------------------------------------------------
-    # CTE formatting: paren on its own line, comma-prefix separator;
-    # table alias with columns gets a space before the column list
+    # CTE formatting: paren on its own line, comma-prefix separator
     # ------------------------------------------------------------------
 
     def tablealias_sql(self, expression: exp.TableAlias) -> str:
@@ -299,8 +298,10 @@ class JarifyGenerator(DuckDB.Generator):
         if not alias and not self.dialect.UNNEST_COLUMN_ONLY:
             alias = self._next_name()
 
-        # Add a space between name and column list: "t (a, b)" not "t(a, b)"
-        return f"{alias} {columns_sql}" if alias and columns_sql else f"{alias}{columns_sql}"
+        # Space before column list only in CTE context: "cte_name (col1, col2)"
+        # Table function aliases like UNNEST keep no space: "t(col)"
+        sep = " " if isinstance(expression.parent, exp.CTE) else ""
+        return f"{alias}{sep}{columns_sql}" if alias and columns_sql else f"{alias}{columns_sql}"
 
     def cte_sql(self, expression: exp.CTE) -> str:
         # Pop comments to prevent double-rendering.  sqlglot attaches leading

--- a/tests/fixtures/joins/cross_join_unnest_alias.expected.sql
+++ b/tests/fixtures/joins/cross_join_unnest_alias.expected.sql
@@ -1,0 +1,6 @@
+SELECT
+   so.id
+  ,t.filter_data
+FROM sales_orders so
+CROSS JOIN UNNEST((so.incentive_data->'filters')::json[]) AS t(filter_data)
+;

--- a/tests/fixtures/joins/cross_join_unnest_alias.input.sql
+++ b/tests/fixtures/joins/cross_join_unnest_alias.input.sql
@@ -1,0 +1,1 @@
+SELECT so.id, t.filter_data FROM sales_orders AS so CROSS JOIN UNNEST((so.incentive_data->'filters')::json[]) AS t(filter_data)


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Claude Code (claude-sonnet-4-6) on behalf of @johnallen3d.

## Summary

- `tablealias_sql` was unconditionally adding a space between the alias name and its column list, turning `AS t(filter_data)` into `AS t (filter_data)` for all `TableAlias` nodes
- Fix checks the parent node type: the space is preserved for CTE column lists (`cte_name (col1, col2)`) but omitted for table function aliases like `UNNEST(...) AS t(col)`
- Adds a fixture test covering `CROSS JOIN UNNEST(...) AS t(filter_data)`

Resolves #178
