### PR TITLE
fix(fmt): normalise OUTER before computing join alias alignment width

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -496,7 +496,16 @@ class JarifyGenerator(DuckDB.Generator):
         entries.append((len("FROM"), from_ref, from_expr.this))
 
         for join in joins:
-            kw = self._join_keyword(join)
+            # Normalize OUTER before measuring keyword length so the alignment
+            # width matches what join_sql actually renders.  For example,
+            # LEFT OUTER JOIN (15 chars) is rendered as LEFT JOIN (9 chars),
+            # so we must use the post-normalization keyword here.
+            if join.side in ("LEFT", "RIGHT") and join.kind == "OUTER":
+                normalized = join.copy()
+                normalized.set("kind", None)
+                kw = self._join_keyword(normalized)
+            else:
+                kw = self._join_keyword(join)
             ref = self._table_ref_only_sql(join.this)
             if ref is None:
                 return None

--- a/tests/fixtures/joins/outer_join_alias_alignment.expected.sql
+++ b/tests/fixtures/joins/outer_join_alias_alignment.expected.sql
@@ -1,0 +1,6 @@
+SELECT DISTINCT
+   t.sku_key
+FROM read_arrow(?, ?)  t
+LEFT JOIN sku_catalog sc ON sc.sku_key = t.sku_key
+WHERE sc.sku_key IS NULL
+;

--- a/tests/fixtures/joins/outer_join_alias_alignment.input.sql
+++ b/tests/fixtures/joins/outer_join_alias_alignment.input.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT t.sku_key FROM read_arrow(?, ?) t LEFT OUTER JOIN sku_catalog sc ON sc.sku_key = t.sku_key WHERE sc.sku_key IS NULL;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by OpenAI Codex (gpt-5.5) on behalf of @johnallen3d.

## Summary

`LEFT OUTER JOIN` (and `RIGHT OUTER JOIN`) are correctly normalised to `LEFT JOIN` / `RIGHT JOIN` during formatting — but the table-alias alignment width was computed **before** that normalisation, causing the padding column to be based on the longer pre-normalisation keyword. The result was excessive whitespace before every aliased table name in the `FROM`/`JOIN` block.

### Before

```sql
FROM read_arrow(?, ?)        t
LEFT JOIN sku_catalog       sc ON sc.sku_key = t.sku_key
```

### After

```sql
FROM read_arrow(?, ?)  t
LEFT JOIN sku_catalog sc ON sc.sku_key = t.sku_key
```

## Changes

- `src/jarify/generator.py` — `_compute_join_align_width`: apply the same `LEFT/RIGHT OUTER → LEFT/RIGHT` normalisation before calling `_join_keyword`, so the measured keyword length matches what `join_sql` actually renders.
- `tests/fixtures/joins/outer_join_alias_alignment.{input,expected}.sql` — new fixture covering `LEFT OUTER JOIN` with aliased tables.

Resolves #181
