### PR TITLE
feat(fmt): always emit CASE expressions as multi-line in pretty mode

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -601,6 +601,42 @@ FROM t
 
 ---
 
+### `CASE` — always multi-line
+
+`CASE` expressions are always formatted across multiple lines in pretty mode, regardless of branch count or line length. Each `WHEN … THEN` pair appears on its own line, and `THEN` values are column-aligned when all branches fit on a single line.
+
+**Bad** (flattened to one line)
+```sql
+SELECT CASE o.part WHEN 'AND' THEN '&&' WHEN 'OR' THEN '||' WHEN 'NOT' THEN '!' ELSE ifnull(qr.met::text, o.part) END AS expr
+FROM data
+```
+
+**Good**
+```sql
+SELECT
+   *
+  ,CASE o.part
+    WHEN 'AND' THEN '&&'
+    WHEN 'OR'  THEN '||'
+    WHEN 'NOT' THEN '!'
+    ELSE ifnull(qr.met::text, o.part)
+  END AS expr
+FROM data
+```
+
+**Also good** (even 2 branches go multi-line)
+```sql
+SELECT
+   CASE status
+    WHEN 'active'   THEN true
+    WHEN 'inactive' THEN false
+    ELSE NULL
+  END AS is_active
+FROM accounts
+```
+
+---
+
 ### `SELECT *` — rewritten as FROM-first
 
 `SELECT *` is rewritten to DuckDB's FROM-first syntax, omitting the `SELECT` clause entirely. Applies only when there are no JOINs.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -693,7 +693,9 @@ class JarifyGenerator(DuckDB.Generator):
 
         compact_stmts = _build(align=False)
         compact_inline = " ".join(compact_stmts)
-        if not (self.pretty and self.too_wide([compact_inline])):
+        # In pretty mode, always emit multi-line — every WHEN/ELSE branch on its
+        # own line. Inline only in non-pretty (e.g. compact sub-expression) mode.
+        if not self.pretty:
             return compact_inline
 
         # Multi-line: align THEN when all branches have single-line THEN values

--- a/tests/fixtures/complex/real_world.expected.sql
+++ b/tests/fixtures/complex/real_world.expected.sql
@@ -61,7 +61,10 @@ SELECT
   ,p.program_redemption_price
   ,p.origin
   ,all_e.participant_key
-  ,CASE WHEN e.participant_key IS NOT NULL THEN 'Y' ELSE 'N' END AS enrolled
+  ,CASE
+    WHEN e.participant_key IS NOT NULL THEN 'Y'
+    ELSE 'N'
+  END AS enrolled
   ,sc.version
 FROM _relevant_skus rs
 INNER JOIN _sku_catalog sc ON sc.sku_key = rs.sku_key AND sc.manufacturer_key = rs.program_supplier_key

--- a/tests/fixtures/select/case_when_inline.expected.sql
+++ b/tests/fixtures/select/case_when_inline.expected.sql
@@ -1,6 +1,10 @@
--- simple searched case: short THEN values stay on one line
+-- simple searched case: short THEN values, multi-line
 SELECT
-   CASE status WHEN 'active' THEN true WHEN 'inactive' THEN false ELSE NULL END AS is_active
+   CASE status
+    WHEN 'active'   THEN true
+    WHEN 'inactive' THEN false
+    ELSE NULL
+  END AS is_active
 FROM accounts
 ;
 
@@ -16,8 +20,12 @@ SELECT
 FROM t
 ;
 
--- general case expression: short THEN values stay on one line
+-- general case expression: short THEN values, multi-line
 SELECT
-   CASE WHEN x > 0 THEN 'positive' WHEN x < 0 THEN 'negative' ELSE 'zero' END AS sign
+   CASE
+    WHEN x > 0 THEN 'positive'
+    WHEN x < 0 THEN 'negative'
+    ELSE 'zero'
+  END AS sign
 FROM t
 ;

--- a/tests/fixtures/select/case_when_inline.input.sql
+++ b/tests/fixtures/select/case_when_inline.input.sql
@@ -1,4 +1,4 @@
--- simple searched case: short THEN values stay on one line
+-- simple searched case: short THEN values, multi-line
 SELECT
   CASE status
     WHEN 'active' THEN true
@@ -20,7 +20,7 @@ SELECT
 FROM t
 ;
 
--- general case expression: short THEN values stay on one line
+-- general case expression: short THEN values, multi-line
 SELECT
   CASE
     WHEN x > 0 THEN 'positive'

--- a/tests/fixtures/select/case_when_multiline_threshold.expected.sql
+++ b/tests/fixtures/select/case_when_multiline_threshold.expected.sql
@@ -1,0 +1,20 @@
+-- 3 WHEN branches: always multi-line
+SELECT
+   *
+  ,CASE o.part
+    WHEN 'AND' THEN '&&'
+    WHEN 'OR'  THEN '||'
+    WHEN 'NOT' THEN '!'
+    ELSE ifnull(qr.met::text, o.part)
+  END AS expr
+FROM data
+;
+
+-- 2 WHEN branches: also multi-line (all CASE always multi-line in pretty mode)
+SELECT
+   CASE status
+    WHEN 'active'   THEN true
+    WHEN 'inactive' THEN false
+  END AS is_active
+FROM t
+;

--- a/tests/fixtures/select/case_when_multiline_threshold.input.sql
+++ b/tests/fixtures/select/case_when_multiline_threshold.input.sql
@@ -1,0 +1,20 @@
+-- 3 WHEN branches: always multi-line
+SELECT
+  *
+ ,CASE o.part
+    WHEN 'AND' THEN '&&'
+    WHEN 'OR'  THEN '||'
+    WHEN 'NOT' THEN '!'
+    ELSE coalesce(qr.met::text, o.part)
+  END AS expr
+FROM data
+;
+
+-- 2 WHEN branches: also multi-line (all CASE always multi-line in pretty mode)
+SELECT
+  CASE status
+    WHEN 'active' THEN true
+    WHEN 'inactive' THEN false
+  END AS is_active
+FROM t
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary

`CASE` expressions are now **always** formatted across multiple lines in pretty mode — regardless of branch count or line length.

**Before** — any short CASE got flattened:
```sql
SELECT
   CASE status WHEN 'active' THEN true WHEN 'inactive' THEN false ELSE NULL END AS is_active
FROM accounts
```

**After** — always multi-line:
```sql
SELECT
   CASE status
    WHEN 'active'   THEN true
    WHEN 'inactive' THEN false
    ELSE NULL
  END AS is_active
FROM accounts
```

Inline rendering is still used in non-pretty (compact sub-expression) contexts, so `CASE` nested inside `WHERE`/`HAVING` conditions remains compact where needed.

## Changes

- `src/jarify/generator.py` — `case_sql`: skip inline path in pretty mode entirely
- `tests/fixtures/select/case_when_inline.{input,expected}.sql` — updated comments; expected output now multi-line for all cases
- `tests/fixtures/select/case_when_multiline_threshold.{input,expected}.sql` — updated comments to reflect unconditional rule
- `docs/sql-style-guide.md` — updated `CASE` section: "always multi-line"

Resolves #188
