### PR TITLE
feat(rules): promote prefer-group-by-all to auto-fix formatter rule

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -903,7 +903,7 @@ QUALIFY
 
 ### `prefer-group-by-all`
 
-Flag explicit `GROUP BY col1, col2, ...` when all non-aggregated `SELECT` columns are listed. Use `GROUP BY ALL` instead.
+**Auto-fixed by `fmt`.** Rewrites explicit `GROUP BY col1, col2, ...` to `GROUP BY ALL` when all non-aggregated `SELECT` columns are listed.
 
 **Bad**
 ```sql

--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -1,15 +1,15 @@
-"""Rule: suggest GROUP BY ALL when all non-aggregated SELECT columns are listed."""
+"""Rule: rewrite explicit GROUP BY column list to GROUP BY ALL when equivalent."""
 
 from __future__ import annotations
 
 import sqlglot.expressions as exp
 
-from jarify.rules.base import LintOnlyRule, _node_pos
+from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 
-class PreferGroupByAllRule(LintOnlyRule):
-    """Lint: flag explicit GROUP BY col list when GROUP BY ALL would be equivalent."""
+class PreferGroupByAllRule(FormatterRule):
+    """Format and lint: rewrite explicit GROUP BY col list to GROUP BY ALL when equivalent."""
 
     def __init__(self, severity: str = "warn") -> None:
         self.severity = severity
@@ -17,6 +17,31 @@ class PreferGroupByAllRule(LintOnlyRule):
     @property
     def name(self) -> str:
         return "prefer-group-by-all"
+
+    def apply(self, tree: exp.Expression) -> exp.Expression:
+        """Rewrite GROUP BY <cols> → GROUP BY ALL when all non-agg SELECT cols are covered."""
+        for select in tree.find_all(exp.Select):
+            group = select.args.get("group")
+            if not group or not group.expressions:
+                continue
+            if group.args.get("all"):
+                continue
+
+            non_agg_sqls: list[str] = []
+            for item in select.expressions:
+                inner = item.this if isinstance(item, exp.Alias) else item
+                if not inner.find(exp.AggFunc):
+                    non_agg_sqls.append(inner.sql(dialect="duckdb"))
+
+            if not non_agg_sqls:
+                continue
+
+            group_sqls = {e.sql(dialect="duckdb") for e in group.expressions}
+            if set(non_agg_sqls) == group_sqls:
+                group.set("all", True)
+                group.set("expressions", [])
+
+        return tree
 
     def check(self, tree: exp.Expression) -> list[LintViolation]:
         if self.severity == "off":

--- a/tests/fixtures/select/group_by_all.expected.sql
+++ b/tests/fixtures/select/group_by_all.expected.sql
@@ -1,0 +1,7 @@
+SELECT
+   a
+  ,b
+  ,SUM(c) AS total
+FROM t
+GROUP BY ALL
+;

--- a/tests/fixtures/select/group_by_all.input.sql
+++ b/tests/fixtures/select/group_by_all.input.sql
@@ -1,0 +1,8 @@
+SELECT
+    a
+  , b
+  , SUM(c) AS total
+FROM t
+GROUP BY
+    a
+  , b

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -205,10 +205,15 @@ class TestJoinFormatting:
 
 class TestGroupByPerLine:
     def test_group_by_multi_column_one_per_line(self):
+        # When all non-agg columns are in GROUP BY, the formatter rewrites to GROUP BY ALL.
         out, _ = format_sql("SELECT a, b, count(*) FROM t GROUP BY a, b")
+        assert "GROUP BY ALL" in out
+
+    def test_group_by_explicit_when_partial(self):
+        # When only a subset of non-agg columns is listed, keep explicit GROUP BY.
+        out, _ = format_sql("SELECT a, b, c, count(*) FROM t GROUP BY a, b")
         lines = out.splitlines()
         group_by_idx = next(i for i, line in enumerate(lines) if "GROUP BY" in line)
-        # The line with GROUP BY should not contain column names on the same line
         group_by_line = lines[group_by_idx]
         assert group_by_line.strip() == "GROUP BY", f"Expected 'GROUP BY' on its own line, got: {group_by_line!r}"
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by pi (claude-sonnet-4-5) on behalf of @johnallen3d.

## Summary

`PreferGroupByAllRule` was a `LintOnlyRule` — it would flag explicit `GROUP BY col1, col2, ...` when all non-aggregated `SELECT` columns were listed, but `fmt` never fixed it. That left formatter and linter inconsistent: lint reported a violation that `fmt` silently ignored.

This PR promotes the rule to a full `FormatterRule` so `fmt` rewrites the pattern automatically.

## Changes

- **`src/jarify/rules/prefer_group_by_all.py`** — change base class from `LintOnlyRule` to `FormatterRule`; implement `apply()` that rewrites `GROUP BY <cols>` → `GROUP BY ALL` using `group.set("all", True)` when all non-aggregated `SELECT` columns match the `GROUP BY` list
- **`tests/fixtures/select/group_by_all.{input,expected}.sql`** — new fixture pair
- **`tests/test_formatter.py`** — update `test_group_by_multi_column_one_per_line` to assert `GROUP BY ALL`; add `test_group_by_explicit_when_partial` for the case where only a subset of non-agg columns is listed (no rewrite)
- **`docs/sql-style-guide.md`** — note that `prefer-group-by-all` is now auto-fixed by `fmt`

## Verification

```
mise run check  →  196 passed, 0 failed
```

Resolves #191
