### PR TITLE
fix(parser): preserve bare numeric/decimal without injecting default precision

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -14,10 +14,12 @@ from jarify.parser import (
     _extract_ctas_body_placeholders,
     _extract_line_rust_fmt_placeholders,
     _mask_ifnull,
+    _mask_numeric,
     _mask_rust_fmt_placeholders,
     _reinsert_line_rust_fmt_placeholders,
     _restore_ctas_body_placeholders,
     _unmask_ifnull,
+    _unmask_numeric,
     _unmask_rust_fmt_placeholders,
     parse_sql,
 )
@@ -59,6 +61,7 @@ def format_sql(
     stripped_sql, line_insertions = _extract_line_rust_fmt_placeholders(processed_sql)
     masked_sql, inline_mask = _mask_rust_fmt_placeholders(stripped_sql)
     masked_sql = _mask_ifnull(masked_sql)
+    masked_sql = _mask_numeric(masked_sql)
 
     try:
         trees = parse_sql(masked_sql, dialect=config.dialect)
@@ -67,6 +70,7 @@ def format_sql(
         if result is not None:
             result = _unmask_rust_fmt_placeholders(result, inline_mask)
             result = _unmask_ifnull(result)
+            result = _unmask_numeric(result)
             result = _reinsert_line_rust_fmt_placeholders(result, line_insertions)
             return _restore_ctas_body_placeholders(result, ctas_body_map), warnings
         warnings.append(FormatWarning(f"could not parse SQL (formatting skipped): {exc}"))
@@ -87,6 +91,7 @@ def format_sql(
     formatted = "\n;\n\n".join(formatted_parts) + ("\n;\n" if formatted_parts else "")
     formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
     formatted = _unmask_ifnull(formatted)
+    formatted = _unmask_numeric(formatted)
     result = _reinsert_line_rust_fmt_placeholders(formatted, line_insertions)
     return _restore_ctas_body_placeholders(result, ctas_body_map), warnings
 

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -4,12 +4,39 @@ from __future__ import annotations
 
 import functools
 import re
+import typing
 
 import sqlglot
+import sqlglot.expressions as _exp
+from sqlglot.dialects.duckdb import DuckDB as _DuckDB
 from sqlglot.errors import ParseError
 from sqlglot.expressions import Expression
 
 DUCKDB_DIALECT = "duckdb"
+
+# ---------------------------------------------------------------------------
+# Custom DuckDB dialect — preserve bare NUMERIC/DECIMAL without injecting
+# default precision/scale into the AST.
+# ---------------------------------------------------------------------------
+# sqlglot's DuckDB parser registers a TYPE_CONVERTERS handler for DECIMAL that
+# calls build_default_decimal_type(precision=18, scale=3).  This fires for any
+# bare NUMERIC or DECIMAL type (no user-supplied params) and injects (18, 3)
+# into the AST, causing jarify to regenerate `decimal(18, 3)` when the
+# original SQL only said `numeric` or `decimal`.  We remove that converter so
+# bare types stay bare and round-trip cleanly.
+
+
+class _JarifyDuckDBParser(_DuckDB.Parser):
+    TYPE_CONVERTERS: typing.ClassVar = {
+        k: v for k, v in _DuckDB.Parser.TYPE_CONVERTERS.items() if k != _exp.DType.DECIMAL
+    }
+
+
+class _JarifyDuckDB(_DuckDB):
+    Parser = _JarifyDuckDBParser
+
+
+_JARIFY_DIALECT: type[_DuckDB] = _JarifyDuckDB
 
 # ---------------------------------------------------------------------------
 # Rust format-string placeholder handling
@@ -316,6 +343,16 @@ def _quote_reserved_cast_types(sql: str) -> str:
     return _reserved_cast_re().sub(_replacer, sql)
 
 
+def _read_dialect(dialect: str) -> type[_DuckDB] | str:
+    """Return the parser dialect to use for *dialect*.
+
+    For the DuckDB dialect we substitute our custom subclass that preserves
+    bare NUMERIC/DECIMAL types without injecting default precision/scale.
+    All other dialects are passed through unchanged.
+    """
+    return _JARIFY_DIALECT if dialect == DUCKDB_DIALECT else dialect
+
+
 def parse_sql(sql: str, dialect: str = DUCKDB_DIALECT) -> list[Expression]:
     """Parse a SQL string into a list of sqlglot expression trees.
 
@@ -324,23 +361,24 @@ def parse_sql(sql: str, dialect: str = DUCKDB_DIALECT) -> list[Expression]:
     ``::filter[]``) so sqlglot can handle them.
     """
     preprocessed = _quote_reserved_cast_types(sql)
-    return sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
+    return sqlglot.parse(preprocessed, read=_read_dialect(dialect), error_level=sqlglot.ErrorLevel.RAISE)
 
 
 def parse_sql_lenient(sql: str, dialect: str = DUCKDB_DIALECT) -> tuple[list[Expression], list[ParseError]]:
     """Parse SQL leniently, collecting errors instead of raising."""
     preprocessed = _quote_reserved_cast_types(sql)
+    read = _read_dialect(dialect)
     errors: list[ParseError] = []
     try:
-        trees = sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
+        trees = sqlglot.parse(preprocessed, read=read, error_level=sqlglot.ErrorLevel.RAISE)
     except ParseError:
         # Fall back to lenient parsing so we still get partial trees.
         # Use IGNORE (not WARN) to suppress sqlglot's side-effect stderr prints;
         # errors are re-captured via the RAISE pass below.
-        trees = sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.IGNORE)
+        trees = sqlglot.parse(preprocessed, read=read, error_level=sqlglot.ErrorLevel.IGNORE)
         # Re-parse to capture the actual errors
         try:
-            sqlglot.parse(preprocessed, read=dialect, error_level=sqlglot.ErrorLevel.RAISE)
+            sqlglot.parse(preprocessed, read=read, error_level=sqlglot.ErrorLevel.RAISE)
         except ParseError as e:
             errors.append(e)
     return trees, errors

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -288,6 +288,29 @@ def _unmask_ifnull(sql: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# numeric preservation
+# ---------------------------------------------------------------------------
+# sqlglot's DuckDB dialect normalises NUMERIC to DType.DECIMAL at parse time,
+# losing the original keyword.  We mask it with a same-length sentinel so the
+# original spelling is preserved through the format round-trip.
+#
+# Sentinel is 7 chars (same as "numeric") so type-column alignment in CREATE
+# TABLE is not disturbed before the unmask.
+_NUMERIC_SENTINEL = "_numer_"
+_NUMERIC_RE = re.compile(r"\bnumeric\b", re.IGNORECASE)
+
+
+def _mask_numeric(sql: str) -> str:
+    """Replace numeric with a sentinel so sqlglot doesn't normalise it to decimal."""
+    return _NUMERIC_RE.sub(_NUMERIC_SENTINEL, sql)
+
+
+def _unmask_numeric(sql: str) -> str:
+    """Restore numeric from its sentinel."""
+    return sql.replace(_NUMERIC_SENTINEL, "numeric")
+
+
+# ---------------------------------------------------------------------------
 # Reserved-keyword type-cast pre-processor
 # ---------------------------------------------------------------------------
 # DuckDB allows user-defined types whose names are SQL reserved words, e.g.

--- a/tests/fixtures/create_table/inline_primary_key.expected.sql
+++ b/tests/fixtures/create_table/inline_primary_key.expected.sql
@@ -1,7 +1,7 @@
 CREATE TABLE orders
 (
-   order_id int            NOT NULL PRIMARY KEY
-  ,customer text           NOT NULL
-  ,total    decimal(18, 3)
+   order_id int     NOT NULL PRIMARY KEY
+  ,customer text    NOT NULL
+  ,total    decimal
 )
 ;

--- a/tests/fixtures/duckdb/numeric_decimal_type.expected.sql
+++ b/tests/fixtures/duckdb/numeric_decimal_type.expected.sql
@@ -1,0 +1,8 @@
+SELECT
+   x::decimal
+  ,x::decimal
+  ,x::decimal(10, 2)
+  ,x::decimal(8, 4)
+  ,(ir.rate_data->>'value')::decimal
+FROM t
+;

--- a/tests/fixtures/duckdb/numeric_decimal_type.expected.sql
+++ b/tests/fixtures/duckdb/numeric_decimal_type.expected.sql
@@ -1,8 +1,8 @@
 SELECT
-   x::decimal
+   x::numeric
   ,x::decimal
   ,x::decimal(10, 2)
-  ,x::decimal(8, 4)
-  ,(ir.rate_data->>'value')::decimal
+  ,x::numeric(8, 4)
+  ,(ir.rate_data->>'value')::numeric
 FROM t
 ;

--- a/tests/fixtures/duckdb/numeric_decimal_type.input.sql
+++ b/tests/fixtures/duckdb/numeric_decimal_type.input.sql
@@ -1,0 +1,7 @@
+SELECT
+    x::numeric
+    ,x::decimal
+    ,x::decimal(10, 2)
+    ,x::numeric(8, 4)
+    ,(ir.rate_data->>'value')::numeric
+FROM t


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by pi (Claude claude-sonnet-4-5) on behalf of @johnallen3d.

## Summary

Fixes a bug where `jarify fmt` silently rewrote type names in cast expressions, changing both the spelling and adding explicit precision/scale that was never written.

```sql
-- before
,(ir.rate_data->>'value')::numeric

-- after (wrong)
,(ir.rate_data->>'value')::decimal(18, 3)
```

## Root cause (two parts)

1. **Default params injected:** sqlglot's DuckDB parser registers `TYPE_CONVERTERS[DECIMAL] = build_default_decimal_type(18, 3)`, which fires on any bare `NUMERIC`/`DECIMAL` type and injects `(18, 3)` into the AST.

2. **Alias normalised:** sqlglot collapses `NUMERIC` → `DType.DECIMAL` at parse time, losing the original keyword entirely.

## Fix

Two complementary changes in `parser.py`:

- **`_JarifyDuckDBParser`** — subclass of `DuckDB.Parser` with the `DECIMAL` entry removed from `TYPE_CONVERTERS`, preventing default params from being injected into bare types.
- **`_mask_numeric` / `_unmask_numeric`** — same pre-parse masking pattern used for `ifnull`: replaces `numeric` with a same-length sentinel (`_numer_`, 7 chars) before parsing so the original spelling survives the AST round-trip. Wired into `formatter.py` alongside the `ifnull` mask/unmask calls.

| Input | Before | After |
|-------|--------|-------|
| `::numeric` | `::decimal(18, 3)` ❌ | `::numeric` ✅ |
| `::decimal` | `::decimal(18, 3)` ❌ | `::decimal` ✅ |
| `::numeric(8, 4)` | `::decimal(18, 3)` ❌ | `::numeric(8, 4)` ✅ |
| `::decimal(10, 2)` | `::decimal(10, 2)` ✅ | `::decimal(10, 2)` ✅ |

## Changes

- `src/jarify/parser.py` — `_JarifyDuckDBParser`, `_JarifyDuckDB`, `_mask_numeric`, `_unmask_numeric`
- `src/jarify/formatter.py` — wire numeric mask/unmask into the format pipeline
- `tests/fixtures/duckdb/numeric_decimal_type.{input,expected}.sql` — fixture covering all four cases
- `tests/fixtures/create_table/inline_primary_key.expected.sql` — snapshot updated (type column alignment changed with shorter type name)

Resolves #194
