### PR TITLE
fix(formatter): place trailing rust fmt placeholder before statement terminator

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -88,11 +88,20 @@ def format_sql(
         tree = _apply_rules(tree, rules)
         formatted_parts.append(generator.generate(tree))
 
-    formatted = "\n;\n\n".join(formatted_parts) + ("\n;\n" if formatted_parts else "")
+    # Join statements but hold off on the trailing ;\n -- it must come *after*
+    # no-anchor line placeholders are re-inserted, otherwise a trailing
+    # {placeholder} ends up after the semicolon instead of before it, which
+    # breaks SQL templates that use the placeholder as an optional WHERE clause.
+    # A trailing \n is appended to ensure the last line ends with a newline so
+    # that no-anchor placeholder re-insertion does not concatenate directly onto
+    # the last SQL token without a line break.
+    formatted = "\n;\n\n".join(formatted_parts) + ("\n" if formatted_parts else "")
     formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
     formatted = _unmask_ifnull(formatted)
     formatted = _unmask_numeric(formatted)
     result = _reinsert_line_rust_fmt_placeholders(formatted, line_insertions)
+    if formatted_parts:
+        result = result.rstrip() + "\n;\n"
     return _restore_ctas_body_placeholders(result, ctas_body_map), warnings
 
 

--- a/tests/fixtures/templates/rust_fmt_trailing_placeholder.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_trailing_placeholder.expected.sql
@@ -1,0 +1,7 @@
+SELECT
+   request_id
+  ,invoice_date
+  ,sku_key
+FROM transactions
+{filter}
+;

--- a/tests/fixtures/templates/rust_fmt_trailing_placeholder.input.sql
+++ b/tests/fixtures/templates/rust_fmt_trailing_placeholder.input.sql
@@ -1,0 +1,6 @@
+SELECT
+   request_id
+  ,invoice_date
+  ,sku_key
+FROM transactions
+{filter}

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -225,3 +225,27 @@ class TestGroupByPerLine:
         out, _ = format_sql("SELECT a, count(*) FROM t GROUP BY a")
         assert "GROUP BY" in out
         assert "a" in out
+
+
+class TestTrailingRustFmtPlaceholder:
+    """Trailing whole-line Rust format placeholders must land *before* the
+    statement-terminating semicolon, not after it.
+
+    Regression for: formatter inserts ';' between the last SQL clause and a
+    trailing {placeholder}, producing invalid SQL when Rust substitutes a
+    non-empty value (e.g. 'WHERE seller_key = ...').
+    """
+
+    def test_placeholder_before_semicolon(self):
+        sql = "SELECT a, b\nFROM t\n{filter}"
+        out, _ = format_sql(sql)
+        lines = out.splitlines()
+        filter_idx = next(i for i, line in enumerate(lines) if "{filter}" in line)
+        semi_idx = next(i for i, line in enumerate(lines) if line.strip() == ";")
+        assert filter_idx < semi_idx, f"{{filter}} (line {filter_idx}) must appear before ';' (line {semi_idx}):\n{out}"
+
+    def test_idempotent(self):
+        sql = "SELECT a, b\nFROM t\n{filter}"
+        out, _ = format_sql(sql)
+        out2, _ = format_sql(out)
+        assert out == out2, f"Formatting is not idempotent:\nFirst pass:\n{out}\nSecond pass:\n{out2}"


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary

Fixes a bug where whole-line Rust `format!` placeholders at the **end** of a SQL file were re-inserted *after* the statement-terminating `;` instead of before it.

### What was broken

In SQL template files like `transactions.sql` in `amfaro/calc`, a trailing `{transaction_filter}` placeholder is used to append an optional `WHERE` clause at runtime. After running jarify, the file became:

```sql
FROM _with_prices wp
;
{transaction_filter}
```

When Rust substitutes a non-empty filter, this produces invalid SQL:

```sql
FROM _with_prices wp
;
WHERE seller_key = 'foo'
```

Surfaced in amfaro/calc PR #3169.

### Root cause

`format_sql` assembled the final `\n;\n`-terminated output string **before** calling `_reinsert_line_rust_fmt_placeholders`. No-anchor (end-of-file) placeholder groups were therefore appended after the semicolon.

### Fix

Call `_reinsert_line_rust_fmt_placeholders` on the joined statement string (with trailing `\n` for clean line separation) **before** appending `\n;\n`. A `rstrip() + "\n;\n"` ensures the output is clean regardless of trailing whitespace from re-insertion.

### Verification

- New fixture: `tests/fixtures/templates/rust_fmt_trailing_placeholder`
- New unit tests: `TestTrailingRustFmtPlaceholder` — covers placeholder-before-semicolon and idempotency
- 201 tests pass, lint clean

Resolves #200
