### PR TITLE
fix(rules): treat list() as aggregate in prefer-group-by-all

### DIFF
--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -7,6 +7,10 @@ import sqlglot.expressions as exp
 from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
+# DuckDB's list() aggregate is parsed by sqlglot as exp.List (Func, not AggFunc).
+# Treat it the same as AggFunc so it does not count as a free column reference.
+_AGG_TYPES = (exp.AggFunc, exp.List)
+
 
 def _free_col_refs(expr: exp.Expression) -> set[str]:
     """Return SQL strings of Column nodes in *expr* that are not inside any AggFunc.
@@ -16,7 +20,7 @@ def _free_col_refs(expr: exp.Expression) -> set[str]:
     need the full expression SQL for purely non-aggregate items should call
     ``expr.sql()`` directly instead.
     """
-    if isinstance(expr, exp.AggFunc):
+    if isinstance(expr, _AGG_TYPES):
         return set()
     if isinstance(expr, exp.Column):
         return {expr.sql(dialect="duckdb")}
@@ -47,7 +51,7 @@ def _non_agg_sqls(select: exp.Select) -> set[str]:
     result: set[str] = set()
     for item in select.expressions:
         inner = item.this if isinstance(item, exp.Alias) else item
-        if not inner.find(exp.AggFunc):
+        if not inner.find(*_AGG_TYPES):
             # Entirely non-aggregate — use the whole expression as-is.
             result.add(inner.sql(dialect="duckdb"))
         else:

--- a/tests/fixtures/select/group_by_all_list_agg.expected.sql
+++ b/tests/fixtures/select/group_by_all_list_agg.expected.sql
@@ -1,0 +1,6 @@
+SELECT
+   program_key
+  ,list(group_by_value ORDER BY group_by_value) AS group_by_values
+FROM _values
+GROUP BY ALL
+;

--- a/tests/fixtures/select/group_by_all_list_agg.input.sql
+++ b/tests/fixtures/select/group_by_all_list_agg.input.sql
@@ -1,0 +1,7 @@
+SELECT
+    program_key
+  , list(group_by_value ORDER BY group_by_value) AS group_by_values
+FROM _values
+GROUP BY
+    program_key
+;

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -211,6 +211,20 @@ class TestPreferGroupByAll:
         rules = _lint(sql, prefer_group_by_all="off")
         assert "prefer-group-by-all" not in rules
 
+    def test_warns_when_list_agg_present(self):
+        # list() in DuckDB is parsed as exp.List (not exp.AggFunc); it must be
+        # treated as an aggregate so the rule fires correctly.
+        sql = "SELECT program_key, list(val ORDER BY val) AS vals FROM t GROUP BY program_key"
+        rules = _lint(sql)
+        assert "prefer-group-by-all" in rules
+
+    def test_no_warn_when_list_agg_is_the_only_expr(self):
+        # If every SELECT item is a list() aggregate there is no non-agg column
+        # to group by, so the rule should not fire.
+        sql = "SELECT list(val ORDER BY val) AS vals FROM t GROUP BY ALL"
+        rules = _lint(sql)
+        assert "prefer-group-by-all" not in rules
+
 
 class TestPreferUsingOverOn:
     def test_warns_on_same_column_name_equijoin(self):


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by OpenAI Codex (gpt-5.5) on behalf of @johnallen3d.

## Summary

Fixes a bug where `prefer-group-by-all` failed to rewrite `GROUP BY program_key` → `GROUP BY ALL` when a `list()` aggregate appeared in the SELECT list.

### Root cause

DuckDB's `list()` aggregate is parsed by sqlglot as `exp.List` (inherits `Func`, not `AggFunc`). The rule's `_non_agg_sqls` helper checked `inner.find(exp.AggFunc)` to classify SELECT items as aggregates — so `list(...)` was treated as non-aggregate, causing the candidate set mismatch that suppressed the rewrite.

### Fix

Introduce `_AGG_TYPES = (exp.AggFunc, exp.List)` and update both `_free_col_refs` and `_non_agg_sqls` to use it. Minimal one-line stop-condition change.

### Changes

- `src/jarify/rules/prefer_group_by_all.py` — `_AGG_TYPES` tuple, updated stop conditions
- `tests/fixtures/select/group_by_all_list_agg.{input,expected}.sql` — new fixture
- `tests/test_lint_rules.py` — two new unit tests for the `list()` case

Resolves #205
