### PR TITLE
fix(fmt): keep IN (SELECT ...) inline when it fits within max line length

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -229,7 +229,7 @@ WHERE type       = _property_type
 
 ### WHERE — `IN (subquery)` layout
 
-An `IN` condition whose right-hand side is a subquery follows the same opening-paren style as CTEs: the `(` goes on its own line, the inner query is indented by one level, and `)` closes at the same column as `IN`.
+When the full `col IN (SELECT ...)` expression fits on one line within the configured max line length, it stays inline. When it would exceed the threshold, the `(` goes on its own line, the inner query is indented by one level, and `)` closes at the same column as `IN`.
 
 **Bad**
 ```sql
@@ -240,13 +240,19 @@ WHERE program_key IN (
   )
 ```
 
-**Good**
+**Good — short subquery stays inline**
+```sql
+WHERE program_key IN (SELECT program_key FROM _programs)
+```
+
+**Good — long subquery expands to block form**
 ```sql
 WHERE program_key IN
 (
   SELECT
      program_key
   FROM _programs
+  WHERE some_very_long_column = 'some_very_long_value_that_exceeds_the_line_length'
 )
 ```
 

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -841,17 +841,26 @@ class JarifyGenerator(DuckDB.Generator):
     # ------------------------------------------------------------------
 
     def in_sql(self, expression: exp.In) -> str:
-        """Render IN with a subquery as col IN\\n(\\n  SELECT ...\\n).
+        """Render IN with a subquery inline when it fits, multiline otherwise.
 
-        The opening paren is placed on its own line at the same indentation
-        level as the enclosing keyword (WHERE/HAVING), so the subquery block
-        mirrors the CTE body style used elsewhere.
+        When the compact form ``col IN (SELECT ...)`` fits within
+        ``max_line_length``, it is kept on a single line.  Only when the
+        inline form would exceed the threshold does it fall back to the
+        block style::
+
+            col IN
+            (
+              SELECT ...
+            )
 
         Falls back to the base generator for IN with a value list.
         """
         query = expression.args.get("query")
         if self.pretty and query is not None:
             this = self.sql(expression, "this")
+            compact = self._compact_sql(query.this)
+            if not self.too_wide([f"{this} IN ({compact})"]):
+                return f"{this} IN ({compact})"
             select_sql = self.sql(query.this)
             indented = self.indent(select_sql)
             return f"{this} IN\n(\n{indented}\n)"

--- a/tests/fixtures/cte/in_subquery.expected.sql
+++ b/tests/fixtures/cte/in_subquery.expected.sql
@@ -5,12 +5,7 @@ WITH _programs AS
 ,_offers AS
 (
   FROM offers
-  WHERE program_key IN
-  (
-    SELECT
-       program_key
-    FROM _programs
-  )
+  WHERE program_key IN (SELECT program_key FROM _programs)
 )
 FROM _offers
 ;

--- a/tests/fixtures/select/in_subquery_inline.expected.sql
+++ b/tests/fixtures/select/in_subquery_inline.expected.sql
@@ -1,0 +1,3 @@
+FROM offers
+WHERE program_key IN (SELECT program_key FROM _programs)
+;

--- a/tests/fixtures/select/in_subquery_inline.input.sql
+++ b/tests/fixtures/select/in_subquery_inline.input.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM offers
+WHERE program_key IN (SELECT program_key FROM _programs)
+;

--- a/tests/fixtures/select/in_subquery_multiline_threshold.expected.sql
+++ b/tests/fixtures/select/in_subquery_multiline_threshold.expected.sql
@@ -1,0 +1,9 @@
+FROM offers
+WHERE program_key IN
+(
+  SELECT
+     program_key
+  FROM _programs
+  WHERE some_very_long_column_name_here = 'a_value_that_makes_this_exceed_the_line_length_threshold'
+)
+;

--- a/tests/fixtures/select/in_subquery_multiline_threshold.input.sql
+++ b/tests/fixtures/select/in_subquery_multiline_threshold.input.sql
@@ -1,0 +1,10 @@
+SELECT *
+FROM offers
+WHERE program_key IN
+(
+  SELECT
+     program_key
+  FROM _programs
+  WHERE some_very_long_column_name_here = 'a_value_that_makes_this_exceed_the_line_length_threshold'
+)
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (gpt-5.5) on behalf of @johnallen3d.

## Summary

`in_sql` in `generator.py` unconditionally expanded `IN (SELECT ...)` subqueries to a multiline block in pretty mode, even when the entire expression was short enough to fit on one line.

Apply the same compact-first / fallback pattern used by `paren_sql` and `join_sql`:

1. Render the subquery compactly via `_compact_sql`.
2. If `not too_wide([f"{this} IN ({compact})"])`, return the inline form.
3. Otherwise fall back to the existing `IN\n(\n  SELECT ...\n)` block.

**Before:**
```sql
FROM offers
WHERE program_key IN
(
  SELECT
     program_key
  FROM _programs
)
;
```

**After:**
```sql
FROM offers
WHERE program_key IN (SELECT program_key FROM _programs)
;
```

Long subqueries that exceed `max_line_length` still expand to the multiline block form.

## Changes

- `src/jarify/generator.py` — `in_sql`: compact-first with `too_wide` fallback
- `tests/fixtures/select/in_subquery_inline.*` — new fixture: short subquery stays inline
- `tests/fixtures/select/in_subquery_multiline_threshold.*` — new fixture: long subquery expands
- `tests/fixtures/cte/in_subquery.expected.sql` — updated to inline (was multiline; subquery is short)
- `docs/sql-style-guide.md` — updated rule with both inline and block-form examples

Resolves #213
