### PR TITLE
fix(parser): use prev_anchor to disambiguate duplicate anchor text

### DIFF
--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -15,7 +15,7 @@ from sqlglot.expressions import Expression
 DUCKDB_DIALECT = "duckdb"
 
 # ---------------------------------------------------------------------------
-# Custom DuckDB dialect — preserve bare NUMERIC/DECIMAL without injecting
+# Custom DuckDB dialect - preserve bare NUMERIC/DECIMAL without injecting
 # default precision/scale into the AST.
 # ---------------------------------------------------------------------------
 # sqlglot's DuckDB parser registers a TYPE_CONVERTERS handler for DECIMAL that
@@ -168,30 +168,42 @@ def _restore_ctas_body_placeholders(sql: str, ctas_body_map: dict[str, str]) -> 
 
 def _extract_line_rust_fmt_placeholders(
     sql: str,
-) -> tuple[str, list[tuple[list[str], list[str], str | None]]]:
+) -> tuple[str, list[tuple[list[str], list[str], str | None, str | None]]]:
     """Strip whole-line Rust format placeholder lines from ``sql``.
 
     Used by the formatter so the stripped SQL can be formatted normally, then
     the placeholders can be re-inserted at the correct positions afterward.
 
-    Returns ``(stripped_sql, [(group, trailing_blanks, anchor), ...])``.
+    Returns ``(stripped_sql, [(group, trailing_blanks, anchor, prev_anchor), ...])``.
     *group* is a list of one or more consecutive placeholder lines (their full
     text, leading whitespace preserved).  *trailing_blanks* is a list of blank
     lines that immediately follow the group — they are consumed here so the
     formatter does not strip them as leading whitespace, and re-emitted by
     ``_reinsert_line_rust_fmt_placeholders``.  *anchor* is the stripped text
     of the first non-blank, non-placeholder line after the group; it is
-    ``None`` when no such line exists.  Grouping consecutive placeholders
-    together ensures they are re-inserted in their original order before the
-    same anchor occurrence.
+    ``None`` when no such line exists.  *prev_anchor* is the stripped text of
+    the last non-blank, non-placeholder line before the group; it is ``None``
+    when no such line exists.  When *anchor* text is not unique in the
+    formatted SQL (e.g. a bare ``)``) *prev_anchor* disambiguates which
+    occurrence to use.  Grouping consecutive placeholders together ensures they
+    are re-inserted in their original order before the same anchor occurrence.
     """
     lines = sql.splitlines(keepends=True)
     result_lines: list[str] = []
-    insertions: list[tuple[list[str], list[str], str | None]] = []
+    insertions: list[tuple[list[str], list[str], str | None, str | None]] = []
 
     i = 0
     while i < len(lines):
         if _RUST_FMT_LINE_RE.match(lines[i]):
+            # Capture the last non-blank, non-placeholder line before the group
+            # so re-insertion can disambiguate when the same anchor text appears
+            # multiple times in the formatted SQL (e.g. bare ")" after every CTE).
+            prev_anchor: str | None = None
+            for j in range(len(result_lines) - 1, -1, -1):
+                candidate = result_lines[j].strip()
+                if candidate and not _RUST_FMT_LINE_RE.match(result_lines[j]):
+                    prev_anchor = candidate
+                    break
             # Collect all adjacent placeholder lines into one group so they
             # are re-inserted together (preserving relative order) before a
             # single anchor occurrence.
@@ -216,7 +228,7 @@ def _extract_line_rust_fmt_placeholders(
                 if candidate and not _RUST_FMT_LINE_RE.match(lines[j]):
                     anchor = candidate
                     break
-            insertions.append((group, trailing_blanks, anchor))
+            insertions.append((group, trailing_blanks, anchor, prev_anchor))
         else:
             result_lines.append(lines[i])
             i += 1
@@ -224,7 +236,10 @@ def _extract_line_rust_fmt_placeholders(
     return "".join(result_lines), insertions
 
 
-def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[str], list[str], str | None]]) -> str:
+def _reinsert_line_rust_fmt_placeholders(
+    sql: str,
+    insertions: list[tuple[list[str], list[str], str | None, str | None]],
+) -> str:
     """Re-insert whole-line placeholder groups into formatted SQL.
 
     Each group is inserted immediately before the first occurrence of its
@@ -232,6 +247,12 @@ def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[s
     the group in their original order.  Trailing blank lines recorded during
     extraction are emitted after the group and before the anchor.  Groups with
     no anchor are appended at the end.
+
+    When a group has a *prev_anchor* (the last non-blank line before the
+    placeholder in the original SQL), an anchor-line match is only accepted
+    when the most recently seen non-blank line in the output also matches
+    *prev_anchor*.  This disambiguates generic anchor text such as a bare
+    ``)``) that appears after every CTE block.
     """
     if not insertions:
         return sql
@@ -242,20 +263,29 @@ def _reinsert_line_rust_fmt_placeholders(sql: str, insertions: list[tuple[list[s
     # occurrences of that anchor in the formatted SQL.
     pending = list(insertions)
     result: list[str] = []
+    last_non_blank: str | None = None
 
     for line in lines:
         stripped = line.strip()
-        for idx, (group, trailing_blanks, anchor) in enumerate(pending):
+        for idx, (group, trailing_blanks, anchor, prev_anchor) in enumerate(pending):
             if anchor is not None and stripped == anchor:
+                # When prev_anchor is set, only accept this occurrence of
+                # anchor if the preceding non-blank output line matches it.
+                # This prevents a placeholder from landing in an earlier CTE
+                # that happens to close with the same token (e.g. ")").
+                if prev_anchor is not None and last_non_blank != prev_anchor:
+                    continue
                 for placeholder in group:
                     result.append(placeholder + "\n")
                 result.extend(trailing_blanks)
                 pending.pop(idx)
                 break
+        if stripped:
+            last_non_blank = stripped
         result.append(line)
 
     # Append any remaining (no-anchor) groups before the trailing newline
-    for group, trailing_blanks, _ in pending:
+    for group, trailing_blanks, _, __ in pending:
         for placeholder in group:
             result.append(placeholder + "\n")
         result.extend(trailing_blanks)
@@ -316,7 +346,7 @@ def _unmask_numeric(sql: str) -> str:
 # DuckDB allows user-defined types whose names are SQL reserved words, e.g.
 #   COALESCE(x, []::filter[])
 # sqlglot fails to parse these because it sees ``filter`` as a keyword token,
-# not a type name.  Quoting them — ``::"filter"[]`` — makes sqlglot parse
+# not a type name.  Quoting them - ``::"filter"[]`` - makes sqlglot parse
 # correctly; the generator then emits the unquoted ``::filter[]`` form again.
 
 

--- a/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
@@ -1,0 +1,15 @@
+WITH _sku_catalog AS
+(
+  FROM sku_catalog
+)
+,_aggregated_and_sorted AS
+(
+  SELECT
+     ARRAY_AGG((f) ORDER BY key) AS skus
+  FROM _final f
+  {manufacturer_filter}
+)
+SELECT
+   skus::json AS skus
+FROM _aggregated_and_sorted
+;

--- a/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.input.sql
+++ b/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.input.sql
@@ -1,0 +1,14 @@
+WITH _sku_catalog AS
+(
+  SELECT *
+  FROM sku_catalog
+)
+,_aggregated_and_sorted AS
+(
+  SELECT array_agg((f) ORDER BY key) AS skus
+  FROM _final f
+  {manufacturer_filter}
+)
+SELECT skus::json AS skus
+FROM _aggregated_and_sorted
+;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -227,6 +227,7 @@ class TestExtractReinsertLinePlaceholders:
             ["{program_filter}", "{example_filter}"],
             ["\n"],
             "CREATE TABLE t AS SELECT 1",
+            None,  # no prev_anchor — nothing before the group
         )
 
     def test_blank_lines_after_placeholder_block_are_preserved(self) -> None:
@@ -249,6 +250,39 @@ class TestExtractReinsertLinePlaceholders:
         ex_idx = lines.index("{example_filter}")
         create_idx = next(i for i, ln in enumerate(lines) if ln.startswith("CREATE TABLE"))
         assert prog_idx < ex_idx < create_idx
+
+    def test_prev_anchor_disambiguates_duplicate_anchor_text(self) -> None:
+        """Regression: placeholder with anchor ')' must land in the correct CTE.
+
+        When two CTEs both close with a bare ')' line, the reinsert algorithm
+        must use prev_anchor to place the placeholder after the right preceding
+        line instead of always taking the first occurrence.
+        """
+        sql = (
+            "WITH a AS (\n"
+            "  SELECT *\n"
+            "  FROM sku_catalog\n"
+            ")\n"
+            ",b AS (\n"
+            "  SELECT count(*) AS n\n"
+            "  FROM _final f\n"
+            "  {manufacturer_filter}\n"
+            ")\n"
+            "SELECT n FROM b\n;"
+        )
+        from jarify.formatter import format_sql
+
+        result, warnings = format_sql(sql)
+        lines = result.splitlines()
+        # The placeholder must appear inside CTE b (after "FROM _final f"),
+        # not inside CTE a (after "FROM sku_catalog").
+        mf_idx = lines.index("  {manufacturer_filter}")
+        # Find the line index for "FROM _final f" and "FROM sku_catalog"
+        final_f_idx = next(i for i, ln in enumerate(lines) if ln.strip() == "FROM _final f")
+        sku_catalog_idx = next(i for i, ln in enumerate(lines) if ln.strip() == "FROM sku_catalog")
+        assert mf_idx > final_f_idx, "placeholder must come after 'FROM _final f'"
+        assert mf_idx > sku_catalog_idx, "placeholder must not be in the sku_catalog CTE"
+        assert warnings == []
 
 
 class TestCtasBodyPlaceholders:


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by OpenAI Codex (gpt-5.5) on behalf of @johnallen3d.

## Summary

Fixes a bug where a whole-line template placeholder (e.g. `{manufacturer_filter}`) could be reinserted into the **wrong CTE** after formatting.

### Root cause

`_extract_line_rust_fmt_placeholders` recorded the *next* non-blank line as the re-insertion `anchor`. When that anchor was a bare `)` — which closes every CTE block — `_reinsert_line_rust_fmt_placeholders` matched the *first* `)` in the formatted SQL instead of the one in the intended CTE.

### Fix

Also capture `prev_anchor` — the last non-blank, non-placeholder line **before** each placeholder group. During re-insertion, an anchor match is only accepted when the most-recently-seen non-blank output line also matches `prev_anchor`. For example, `{manufacturer_filter}` preceded by `FROM _final f` will only land before a `)` that itself follows `FROM _final f`, not before the `)` that follows `FROM sku_catalog` in an earlier CTE.

### Changes

- `src/jarify/parser.py` — `_extract_line_rust_fmt_placeholders` now returns a 4-tuple `(group, trailing_blanks, anchor, prev_anchor)`; `_reinsert_line_rust_fmt_placeholders` signature updated to match and uses `prev_anchor` as a guard
- `tests/test_parser.py` — updated the one tuple-equality assertion; added `test_prev_anchor_disambiguates_duplicate_anchor_text` regression test
- `tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.{input,expected}.sql` — fixture drawn from `calc-core/src/db/sql/skus.sql`

Resolves #216
