### PR TITLE
fix(generator): bypass leading-comma path for DataType in expressions()

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -156,7 +156,7 @@ class JarifyGenerator(DuckDB.Generator):
         dynamic: bool = False,
         new_line: bool = False,
     ) -> str:
-        if not (self.pretty and self.leading_comma) or isinstance(expression, exp.Properties):
+        if not (self.pretty and self.leading_comma) or isinstance(expression, (exp.Properties, exp.DataType)):
             return super().expressions(
                 expression=expression,
                 key=key,

--- a/tests/fixtures/duckdb/struct_cast_field_alignment.expected.sql
+++ b/tests/fixtures/duckdb/struct_cast_field_alignment.expected.sql
@@ -1,0 +1,10 @@
+SELECT
+   sku_key
+  ,ARRAY_AGG((
+     key
+    ,'string'
+    ,value
+  )::struct(key text, type text, value text)) AS external_ids
+FROM sku_external_ids
+GROUP BY ALL
+;

--- a/tests/fixtures/duckdb/struct_cast_field_alignment.input.sql
+++ b/tests/fixtures/duckdb/struct_cast_field_alignment.input.sql
@@ -1,0 +1,6 @@
+SELECT
+   sku_key
+  ,array_agg((key, 'string', value)::STRUCT(key text, type text, value text)) AS external_ids
+FROM sku_external_ids
+GROUP BY ALL
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by OpenAI Codex (gpt-5.5) on behalf of @johnallen3d.

## Summary

Fixes malformed output when formatting `STRUCT` cast expressions. The first field was appearing on the same line as the opening paren (`struct( key text`) with inconsistent indentation for subsequent fields.

**Root cause:** `expressions()` override applied leading-comma formatting unconditionally to all expression types, including `exp.DataType` (STRUCT field lists). The base `datatype_sql` calls `expressions(..., skip_first=True, skip_last=True)`, which caused the first field to land inline with the `(` delimiter.

**Fix:** One-line change — add `exp.DataType` to the existing `exp.Properties` bypass in `expressions()`, so STRUCT field lists use the base generator's flat formatting.

**Before:**
```sql
::struct( key text
    ,type text
  ,value text)
```

**After:**
```sql
::struct(key text, type text, value text)
```

Resolves #219
