### PR TITLE
fix(generator): use compact args in if_sql to prevent mid-condition wrap

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -719,12 +719,38 @@ class JarifyGenerator(DuckDB.Generator):
     def if_sql(self, expression: exp.If) -> str:
         """Render exp.If as DuckDB's IF(cond, then[, else]) function call.
 
-        sqlglot's default converts exp.If back to a CASE WHEN expression;
-        this override preserves the compact IF() form that jarify prefers.
+        In non-pretty mode, delegates to the generic func() helper.
+
+        In pretty mode, builds a compact one-line form using _compact_sql so
+        that boolean conditions (AND / OR chains) are not allowed to wrap
+        mid-argument-list.  When the compact form still exceeds
+        max_line_length, falls back to CASE WHEN … THEN … [ELSE …] END via
+        case_sql(), which always produces clean multi-line output.
         """
-        if expression.args.get("false") is not None:
-            return self.func("IF", expression.this, expression.args["true"], expression.args["false"])
-        return self.func("IF", expression.this, expression.args["true"])
+        has_else = expression.args.get("false") is not None
+
+        if not self.pretty:
+            if has_else:
+                return self.func("IF", expression.this, expression.args["true"], expression.args["false"])
+            return self.func("IF", expression.this, expression.args["true"])
+
+        # Pretty mode: build compact args and check total width.
+        compact_cond = self._compact_sql(expression.this)
+        compact_then = self._compact_sql(expression.args["true"])
+        compact_args = [compact_cond, compact_then]
+        if has_else:
+            compact_args.append(self._compact_sql(expression.args["false"]))
+
+        inline = f"if({', '.join(compact_args)})"
+        if not self.too_wide([inline]):
+            return inline
+
+        # Too wide — fall back to CASE WHEN for clean multi-line output.
+        case = exp.Case(
+            ifs=[exp.If(this=expression.this.copy(), true=expression.args["true"].copy())],
+            **(({"default": expression.args["false"].copy()}) if has_else else {}),
+        )
+        return self.case_sql(case)
 
     # ------------------------------------------------------------------
     # CASE: keep WHEN/THEN on one line; align THEN across branches;

--- a/tests/fixtures/conditionals/if_wide_condition.expected.sql
+++ b/tests/fixtures/conditionals/if_wide_condition.expected.sql
@@ -1,0 +1,14 @@
+-- Wide boolean condition: compact IF() fits on one line → IF() is used
+SELECT
+   if(s.transform IS NOT NULL AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity) AS coverage
+FROM t
+;
+
+-- Very wide: exceeds max_line_length → CASE WHEN fallback
+SELECT
+   CASE
+    WHEN some_really_long_column_name IS NOT NULL AND another_really_long_column_name.some_field = 'some_long_string_value_here' THEN very_long_expression_name / another_quite_long_column_name
+    ELSE fallback_to_this_column_name
+  END AS result
+FROM t
+;

--- a/tests/fixtures/conditionals/if_wide_condition.input.sql
+++ b/tests/fixtures/conditionals/if_wide_condition.input.sql
@@ -1,0 +1,16 @@
+-- Wide boolean condition: compact IF() fits on one line → IF() is used
+SELECT
+  CASE WHEN s.transform IS NOT NULL AND s.transform.type = 'coverage' THEN t.quantity / s.conversion_rate ELSE t.quantity END AS coverage
+FROM t
+;
+
+-- Very wide: exceeds max_line_length → CASE WHEN fallback
+SELECT
+  CASE
+    WHEN some_really_long_column_name IS NOT NULL
+     AND another_really_long_column_name.some_field = 'some_long_string_value_here'
+    THEN very_long_expression_name / another_quite_long_column_name
+    ELSE fallback_to_this_column_name
+  END AS result
+FROM t
+;

--- a/tests/fixtures/select/case_when_and_condition.expected.sql
+++ b/tests/fixtures/select/case_when_and_condition.expected.sql
@@ -2,7 +2,6 @@
 SELECT
    t.*
   ,s.sku_set
-  ,if(s.transform IS NOT NULL
-  AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity) AS coverage
+  ,if(s.transform IS NOT NULL AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity) AS coverage
 FROM transactions t
 ;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary

`if_sql` was calling `self.func("IF", cond, then, else)`, which invokes `self.sql()` on each argument in pretty mode. When the condition contained `AND` / `OR` chains, pretty-mode SQL generation inserted newlines inside the argument list:

```sql
-- Before (broken)
,if(s.transform IS NOT NULL
AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity) AS coverage
```

The `AND` wrapped to a new line while subsequent arguments stayed on the same line — the comma after the condition was easy to miss, making the expression visually ambiguous.

## Fix

In pretty mode, `if_sql` now:

1. Computes compact (non-pretty) renderings of every argument via `_compact_sql`.
2. Assembles the one-line form and checks `too_wide`.
3. **Fits within `max_line_length`** → emits the inline `if(cond, then[, else])`.
4. **Exceeds `max_line_length`** → falls back to `case_sql()`, which always produces clean multi-line `CASE WHEN … THEN … ELSE … END` output.

```sql
-- After (compact, fits on one line)
,if(s.transform IS NOT NULL AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity) AS coverage

-- After (very wide, falls back to CASE/WHEN)
,CASE
   WHEN some_really_long_column_name IS NOT NULL AND another_long_column_name.field = 'value'
   THEN long_expression / another_column
   ELSE fallback_column
 END AS result
```

## Changes

- `src/jarify/generator.py` — `if_sql` method rewritten for pretty mode
- `tests/fixtures/conditionals/if_wide_condition.{input,expected}.sql` — new fixture covering both code paths
- `tests/fixtures/select/case_when_and_condition.expected.sql` — updated to reflect corrected single-line output (the old snapshot captured the broken multi-line form)

Resolves #226
