### PR TITLE
fix(generator): remove CASE fallback from if_sql — always emit IF()

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -721,11 +721,12 @@ class JarifyGenerator(DuckDB.Generator):
 
         In non-pretty mode, delegates to the generic func() helper.
 
-        In pretty mode, builds a compact one-line form using _compact_sql so
-        that boolean conditions (AND / OR chains) are not allowed to wrap
-        mid-argument-list.  When the compact form still exceeds
-        max_line_length, falls back to CASE WHEN … THEN … [ELSE …] END via
-        case_sql(), which always produces clean multi-line output.
+        In pretty mode, renders all arguments through _compact_sql so that
+        boolean conditions (AND / OR chains) cannot emit newlines
+        mid-argument-list.  The result is always a single-line IF() call;
+        no fallback to CASE WHEN is attempted because exp.If is produced
+        both from user-written IF() calls and from CASE WHEN rewrites, and
+        there is no way to distinguish them after parsing.
         """
         has_else = expression.args.get("false") is not None
 
@@ -734,23 +735,14 @@ class JarifyGenerator(DuckDB.Generator):
                 return self.func("IF", expression.this, expression.args["true"], expression.args["false"])
             return self.func("IF", expression.this, expression.args["true"])
 
-        # Pretty mode: build compact args and check total width.
+        # Pretty mode: compact args prevent AND/OR from wrapping mid-call.
         compact_cond = self._compact_sql(expression.this)
         compact_then = self._compact_sql(expression.args["true"])
         compact_args = [compact_cond, compact_then]
         if has_else:
             compact_args.append(self._compact_sql(expression.args["false"]))
 
-        inline = f"if({', '.join(compact_args)})"
-        if not self.too_wide([inline]):
-            return inline
-
-        # Too wide — fall back to CASE WHEN for clean multi-line output.
-        case = exp.Case(
-            ifs=[exp.If(this=expression.this.copy(), true=expression.args["true"].copy())],
-            **(({"default": expression.args["false"].copy()}) if has_else else {}),
-        )
-        return self.case_sql(case)
+        return f"if({', '.join(compact_args)})"
 
     # ------------------------------------------------------------------
     # CASE: keep WHEN/THEN on one line; align THEN across branches;

--- a/tests/fixtures/conditionals/if_wide_condition.expected.sql
+++ b/tests/fixtures/conditionals/if_wide_condition.expected.sql
@@ -1,14 +1,17 @@
--- Wide boolean condition: compact IF() fits on one line → IF() is used
+-- Wide boolean condition in CASE WHEN → rewritten to IF() on one line
 SELECT
    if(s.transform IS NOT NULL AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity) AS coverage
 FROM t
 ;
 
--- Very wide: exceeds max_line_length → CASE WHEN fallback
+-- Very wide CASE WHEN → still IF() on one line (no CASE fallback)
 SELECT
-   CASE
-    WHEN some_really_long_column_name IS NOT NULL AND another_really_long_column_name.some_field = 'some_long_string_value_here' THEN very_long_expression_name / another_quite_long_column_name
-    ELSE fallback_to_this_column_name
-  END AS result
+   if(some_really_long_column_name IS NOT NULL AND another_really_long_column_name.some_field = 'some_long_string_value_here', very_long_expression_name / another_quite_long_column_name, fallback_to_this_column_name) AS result
+FROM t
+;
+
+-- IF() written directly with wide condition → must stay IF(), never rewrite to CASE WHEN
+SELECT
+   if(some_really_long_column_name IS NOT NULL AND another_really_long_column_name.some_field = 'some_long_string_value_here', very_long_expression_name / another_quite_long_column_name, fallback_to_this_column_name) AS result
 FROM t
 ;

--- a/tests/fixtures/conditionals/if_wide_condition.input.sql
+++ b/tests/fixtures/conditionals/if_wide_condition.input.sql
@@ -1,10 +1,10 @@
--- Wide boolean condition: compact IF() fits on one line → IF() is used
+-- Wide boolean condition in CASE WHEN → rewritten to IF() on one line
 SELECT
   CASE WHEN s.transform IS NOT NULL AND s.transform.type = 'coverage' THEN t.quantity / s.conversion_rate ELSE t.quantity END AS coverage
 FROM t
 ;
 
--- Very wide: exceeds max_line_length → CASE WHEN fallback
+-- Very wide CASE WHEN → still IF() on one line (no CASE fallback)
 SELECT
   CASE
     WHEN some_really_long_column_name IS NOT NULL
@@ -12,5 +12,11 @@ SELECT
     THEN very_long_expression_name / another_quite_long_column_name
     ELSE fallback_to_this_column_name
   END AS result
+FROM t
+;
+
+-- IF() written directly with wide condition → must stay IF(), never rewrite to CASE WHEN
+SELECT
+  if(some_really_long_column_name IS NOT NULL AND another_really_long_column_name.some_field = 'some_long_string_value_here', very_long_expression_name / another_quite_long_column_name, fallback_to_this_column_name) AS result
 FROM t
 ;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Problem

After merging #227, running `fmt` over SQL containing wide `if()` calls silently rewrote them to `CASE WHEN … END`:

```sql
-- User wrote this
if(some_really_long_condition IS NOT NULL AND another_long_col = 'value', expr_a, expr_b)

-- fmt produced this (wrong)
CASE
  WHEN some_really_long_condition IS NOT NULL AND another_long_col = 'value' THEN expr_a
  ELSE expr_b
END
```

## Root cause

The `too_wide` fallback in `if_sql` cannot distinguish user-written `if()` from a CASE node rewritten by `PreferIfOverCaseRule` — both parse to `exp.If` and there is no origin metadata in the AST. The fallback was too broad.

## Fix

Remove the CASE/WHEN fallback entirely. The `_compact_sql` arg rendering (the real fix from #227) already prevents the mid-argument `AND`/`OR` wrapping. Wide `IF()` calls stay as a single-line `if(...)` regardless of length.

```sql
-- Before #227: broken mid-argument wrap
if(s.transform IS NOT NULL
AND s.transform.type = 'coverage', t.quantity / s.conversion_rate, t.quantity)

-- After this fix: clean single line (even when wide)
if(some_really_long_condition IS NOT NULL AND another_long_col = 'value', expr_a, expr_b)
```

## Test improvement

The `if_wide_condition` fixture now includes a third case — `if()` written directly with a wide condition — which must survive a `fmt` round-trip unchanged. This is the idempotency regression test that would have caught #229 before merge.

Resolves #229
