### PR TITLE
fix(generator): wrap overlong branches in wide if()

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -1044,3 +1044,22 @@ SELECT
 FROM t
 ;
 ```
+
+When a compact `if(cond, then[, else])` call exceeds `max_line_length`, expand the outer
+`if()` call across multiple lines. Keep the condition compact on one line, but let an
+overlong `true` or `false` branch use its normal nested wrapping.
+
+**Wide**
+```sql
+SELECT
+   if(
+      condition_that_makes_the_call_too_wide
+     ,(
+         very_long_value_a
+        ,very_long_value_b
+        ,very_long_value_c
+      )::some_type
+     ,fallback_value
+  ) AS result
+;
+```

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -725,15 +725,11 @@ class JarifyGenerator(DuckDB.Generator):
         that boolean conditions (AND / OR chains) cannot wrap mid-argument.
 
         When the compact single-line form fits within max_line_length it is
-        used as-is.  When it is too wide the call expands using the same
-        leading-comma style as SELECT column lists (content at pad+1,
-        comma at pad):
-
-            if(
-               <condition>
-              ,<value_if_true>
-              ,<value_if_false>
-            )
+        used as-is. When it is too wide the call expands using a leading-
+        comma outer form like SELECT column lists (content at pad+1, comma
+        at pad). The condition stays compact on one line, but true/false
+        branches may use their normal multi-line formatting when still too
+        wide.
         """
         has_else = expression.args.get("false") is not None
 
@@ -742,38 +738,41 @@ class JarifyGenerator(DuckDB.Generator):
                 return self.func("IF", expression.this, expression.args["true"], expression.args["false"])
             return self.func("IF", expression.this, expression.args["true"])
 
-        # Pretty mode: compact args prevent AND/OR from wrapping mid-call.
+        # Pretty mode: keep the condition compact so AND/OR chains do not
+        # wrap mid-call. Branches start compact too, but can fall back to
+        # their normal SQL rendering when still too wide on their own.
         compact_cond = self._compact_sql(expression.this)
-        compact_then = self._compact_sql(expression.args["true"])
+        true_expr = expression.args["true"]
+        compact_then = self._compact_sql(true_expr)
         compact_args = [compact_cond, compact_then]
-        if has_else:
-            compact_args.append(self._compact_sql(expression.args["false"]))
+
+        false_expr = expression.args.get("false")
+        if false_expr is not None:
+            compact_args.append(self._compact_sql(false_expr))
 
         inline = f"if({', '.join(compact_args)})"
         if not self.too_wide([inline]):
             return inline
 
-        # Too wide: expand to a multi-line leading-comma form that matches
-        # jarify's SELECT column style (content at pad+1, comma at pad).
-        #
-        # sqlglot appends self.pad spaces to every line after the first when
-        # it embeds a multi-line expression into the statement.  To reach the
-        # desired absolute columns we therefore emit one less space and let
-        # sqlglot supply the rest:
-        #
-        #   first arg / closing paren → emit 1 space  (+pad → pad+1, aligns with "if(")
-        #   comma args                → emit ","       (+pad → "  ," at pad col)
-        #
-        # Emit one indentation level inside if(.
-        # sqlglot appends self.pad spaces to every inner line, so to reach
-        # the target absolute columns we emit (target - pad):
-        #   first arg  → 2*(pad+1) cols total → emit pad+2 spaces
-        #   comma args → 2*(pad+1)-1 cols     → emit pad+1 spaces then ","
-        #   closing )  → pad+1 cols (= if col) → emit 1 space
+        branch_sqls = [compact_cond]
+        branch_sqls.append(compact_then if not self.too_wide([compact_then]) else self.sql(true_expr))
+        if false_expr is not None:
+            compact_false = self._compact_sql(false_expr)
+            branch_sqls.append(compact_false if not self.too_wide([compact_false]) else self.sql(false_expr))
+
+        # Too wide: expand the outer IF() with leading commas. Keep the
+        # condition on one compact line, but allow branch expressions to bring
+        # along their own nested wrapping.
         p = self.pad
-        lines = ["if(", f"{' ' * (p + 2)}{compact_args[0]}"]
-        for arg in compact_args[1:]:
-            lines.append(f"{' ' * (p + 1)},{arg}")
+
+        def _prefixed(arg_sql: str, *, first: str, rest: str) -> list[str]:
+            lines = arg_sql.splitlines() or [arg_sql]
+            return [f"{first}{lines[0]}", *(f"{rest}{line}" for line in lines[1:])]
+
+        lines = ["if("]
+        lines.extend(_prefixed(branch_sqls[0], first=" " * (p + 2), rest=" " * (p + 2)))
+        for arg_sql in branch_sqls[1:]:
+            lines.extend(_prefixed(arg_sql, first=" " * (p + 1) + ",", rest=" " * (p + 2)))
         lines.append(")")
         return "\n".join(lines)
 

--- a/tests/fixtures/conditionals/if_wide_condition.expected.sql
+++ b/tests/fixtures/conditionals/if_wide_condition.expected.sql
@@ -23,3 +23,16 @@ SELECT
   ) AS result
 FROM t
 ;
+
+-- Wide IF() with an overlong true-expression → wrap nested branch expression too
+SELECT
+   if(
+      (ir.incentive_data->'transform'->>'type') IS NOT NULL
+     ,(
+         (ir.incentive_data->'transform'->>'type')
+        ,(ir.incentive_data->'transform'->>'from')
+        ,(ir.incentive_data->'transform'->>'based_on')
+      )::transform
+     ,NULL
+  ) AS transform
+;

--- a/tests/fixtures/conditionals/if_wide_condition.input.sql
+++ b/tests/fixtures/conditionals/if_wide_condition.input.sql
@@ -20,3 +20,8 @@ SELECT
   if(some_really_long_column_name IS NOT NULL AND another_really_long_column_name.some_field = 'some_long_string_value_here', very_long_expression_name / another_quite_long_column_name, fallback_to_this_column_name) AS result
 FROM t
 ;
+
+-- Wide IF() with an overlong true-expression → wrap nested branch expression too
+SELECT
+  CASE WHEN (ir.incentive_data->'transform'->>'type') IS NOT NULL THEN ((ir.incentive_data->'transform'->>'type'), (ir.incentive_data->'transform'->>'from'), (ir.incentive_data->'transform'->>'based_on'))::transform ELSE NULL END AS transform
+;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -87,6 +87,19 @@ def test_pivot_order_by_formats_without_warning():
     assert result == result2
 
 
+def test_wide_if_keeps_condition_compact_but_wraps_overlong_true_branch():
+    sql = (
+        "SELECT if((ir.incentive_data->'transform'->>'type') IS NOT NULL, "
+        "((ir.incentive_data->'transform'->>'type'), "
+        "(ir.incentive_data->'transform'->>'from'), "
+        "(ir.incentive_data->'transform'->>'based_on'))::transform, NULL) AS transform"
+    )
+    result, _ = format_sql(sql)
+    assert "(ir.incentive_data->'transform'->>'type') IS NOT NULL\n     ,(" in result
+    assert "\n        ,(ir.incentive_data->'transform'->>'from')" in result
+    assert "\n     ,NULL" in result
+
+
 class TestFromFirst:
     def test_select_star_becomes_from_first(self):
         from jarify.formatter import format_sql


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary

- keep wide `if()` conditions compact so boolean chains do not wrap mid-argument
- let overlong `true` and `false` branches use their normal nested formatting inside a wide `if()`
- add regression coverage for the `./tmp/example.sql` shape and document the nested wrapping rule

## Verification

- `uv run pytest tests/test_formatter.py -k wide_if -q`
- `uv run pytest tests/test_fixtures.py -k if_wide_condition -q`
- `mise run check`

Resolves #233
