### PR TITLE
fix(generator): keep AND/OR connector inline when it fits within max_line_length

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -164,6 +164,7 @@ class JarifyGenerator(DuckDB.Generator):
         self._join_alias_col: int | None = None  # set during FROM/JOIN block rendering
         self._leading_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
         self._trailing_sep_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
+        self._connector_force_expand: bool = False  # set True inside WHERE/HAVING to always break AND/OR
 
     # ------------------------------------------------------------------
     # Function name casing: aggregates/window functions → UPPER, rest → lower
@@ -658,7 +659,11 @@ class JarifyGenerator(DuckDB.Generator):
         return max_total + 1  # +1 for minimum one space before ON/EOL
 
     # ------------------------------------------------------------------
-    # Connector: always break AND/OR onto separate lines in pretty mode
+    # Connector: break AND/OR onto separate lines in pretty mode only when
+    # the compact (single-line) form exceeds max_line_length.  When
+    # _connector_force_expand is True (set by WHERE/HAVING rendering) the
+    # multi-line form is always used so that _inline_clause_sql can
+    # right-justify the operators.
     # ------------------------------------------------------------------
 
     def connector_sql(
@@ -678,6 +683,13 @@ class JarifyGenerator(DuckDB.Generator):
             return super().connector_sql(expression, op)
 
         if self.pretty:
+            if not self._connector_force_expand:
+                compact_parts = [terms[0]]
+                for connector_op, term in zip(ops, terms[1:], strict=False):
+                    compact_parts.append(f"{connector_op} {term}")
+                compact = " ".join(compact_parts)
+                if not self.too_wide([compact]):
+                    return compact
             lines = [terms[0]]
             for connector_op, term in zip(ops, terms[1:], strict=False):
                 lines.append(f"{connector_op} {term}")
@@ -920,7 +932,14 @@ class JarifyGenerator(DuckDB.Generator):
                 if not self.too_wide([f"{keyword} {compact}"]):
                     return self.seg(f"{keyword} {compact}")
 
-        condition_sql = self.sql(expression, "this")
+        # Force connector_sql to produce multi-line output (for post-processing
+        # below) even if the compact form would fit within max_line_length.
+        prev_force = self._connector_force_expand
+        self._connector_force_expand = True
+        try:
+            condition_sql = self.sql(expression, "this")
+        finally:
+            self._connector_force_expand = prev_force
         lines = condition_sql.split("\n")
 
         keyword_width = len(keyword) + 1  # e.g. 6 for "WHERE "

--- a/tests/fixtures/operators/connector_inline_fits.expected.sql
+++ b/tests/fixtures/operators/connector_inline_fits.expected.sql
@@ -1,0 +1,11 @@
+SELECT
+   foo
+  ,array_transform(
+     list_filter(si.filters, f -> f.context = 'direct' OR f.context IS NULL)
+    ,f -> (
+       f.period.period_key
+      ,f.sku_keys
+      ,f.transaction_type
+    )::filter_struct
+  ) AS filters
+;

--- a/tests/fixtures/operators/connector_inline_fits.input.sql
+++ b/tests/fixtures/operators/connector_inline_fits.input.sql
@@ -1,0 +1,11 @@
+SELECT
+   foo
+  ,array_transform(
+     list_filter(si.filters, f -> f.context = 'direct' OR f.context IS NULL)
+    ,f -> (
+       f.period.period_key
+      ,f.sku_keys
+      ,f.transaction_type
+    )::filter_struct
+  ) AS filters
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary

Fixes a bug where `jarify fmt` incorrectly broke `OR`/`AND` connectors onto new lines inside lambda expressions, even when the expression fit within `max_line_length`.

**Before:**
```sql
list_filter(si.filters, f -> f.context = 'direct'
OR f.context IS NULL)
```

**After (idempotent):**
```sql
list_filter(si.filters, f -> f.context = 'direct' OR f.context IS NULL)
```

## Root Cause

`connector_sql` unconditionally expanded `AND`/`OR` chains to multi-line in pretty mode, unlike every other method (`paren_sql`, `if_sql`, `_inline_clause_sql`) which uses `_compact_sql` + `too_wide` before expanding.

## Changes

- `src/jarify/generator.py`:
  - Adds `_connector_force_expand: bool = False` instance flag.
  - `connector_sql` now tries compact inline form first; expands only when `too_wide` or `_connector_force_expand` is set.
  - `_inline_clause_sql` (WHERE/HAVING) sets `_connector_force_expand = True` while rendering its condition, preserving the right-justified AND/OR formatting that clause requires.
- `tests/fixtures/operators/connector_inline_fits.{input,expected}.sql`: new fixture covering the lambda-body case.

Resolves #236
