### PR TITLE
fix(generator): align single-line aliases when SELECT has multi-line alias

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -306,20 +306,21 @@ class JarifyGenerator(DuckDB.Generator):
     def _compute_as_align_width(self, expressions_list: list) -> int | None:
         """Compute the column width for AS alignment in a SELECT expression list.
 
-        Returns None if alignment should not be applied (< 2 aliases, or any
-        aliased column expression spans multiple lines).
-        """
-        aliased = [e for e in expressions_list if isinstance(e, exp.Alias)]
-        if len(aliased) < 2:
-            return None
+        Returns None if alignment should not be applied (< 2 single-line aliases).
 
+        Multi-line aliased expressions (e.g. CASE … END AS foo) are excluded from
+        measurement and from alignment, but their presence no longer disables
+        alignment for the remaining single-line aliases in the same SELECT.
+        """
         col_widths: list[int] = []
+        single_line_alias_count = 0
         for e in expressions_list:
             if isinstance(e, exp.Alias):
                 col_sql = self.sql(e.this)
                 if "\n" in col_sql:
-                    # Multi-line aliased expression — skip alignment for the whole SELECT
-                    return None
+                    # Multi-line aliased expression — skip it, but don't abort
+                    continue
+                single_line_alias_count += 1
                 col_widths.append(len(col_sql))
             else:
                 # Non-aliased columns count toward the alignment width so AS
@@ -327,6 +328,9 @@ class JarifyGenerator(DuckDB.Generator):
                 col_sql = self.sql(e)
                 if "\n" not in col_sql:
                     col_widths.append(len(col_sql))
+
+        if single_line_alias_count < 2:
+            return None
 
         return max(col_widths)
 
@@ -340,7 +344,7 @@ class JarifyGenerator(DuckDB.Generator):
         if not alias_name:
             return this_sql
         align_width = self._as_align_width
-        if align_width is not None and isinstance(expression.parent, exp.Select):
+        if align_width is not None and isinstance(expression.parent, exp.Select) and "\n" not in this_sql:
             padding = " " * max(0, align_width - len(this_sql))
             return f"{this_sql}{padding} AS {alias_name}"
         return f"{this_sql} AS {alias_name}"

--- a/tests/fixtures/conditionals/prefer_if_over_case.expected.sql
+++ b/tests/fixtures/conditionals/prefer_if_over_case.expected.sql
@@ -1,7 +1,7 @@
 SELECT
    a
-  ,if(a > 1, 'big', 'small') AS size
-  ,if(b IS NULL, 0) AS b_or_zero
+  ,if(a > 1, 'big', 'small')   AS size
+  ,if(b IS NULL, 0)            AS b_or_zero
   ,if(status = 'active', 1, 0) AS is_active
   ,CASE
     WHEN a = 1 THEN 'one'

--- a/tests/fixtures/select/alias_alignment_mixed_multiline.expected.sql
+++ b/tests/fixtures/select/alias_alignment_mixed_multiline.expected.sql
@@ -1,0 +1,11 @@
+SELECT
+   a.short           AS key
+  ,a.much_longer_col AS label
+  ,a.no_alias
+  ,CASE
+    WHEN a.x = 1 THEN 'yes'
+    WHEN a.x = 2 THEN 'no'
+    ELSE 'maybe'
+  END AS category
+FROM t a
+;

--- a/tests/fixtures/select/alias_alignment_mixed_multiline.input.sql
+++ b/tests/fixtures/select/alias_alignment_mixed_multiline.input.sql
@@ -1,0 +1,6 @@
+SELECT
+   a.short AS key
+  ,a.much_longer_col AS label
+  ,a.no_alias
+  ,CASE WHEN a.x = 1 THEN 'yes' WHEN a.x = 2 THEN 'no' ELSE 'maybe' END AS category
+FROM t a

--- a/tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.expected.sql
+++ b/tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.expected.sql
@@ -1,0 +1,11 @@
+SELECT
+   a.short           AS key
+  ,a.much_longer_col AS label
+  ,a.no_alias
+  ,CASE
+    WHEN a.x = 1 THEN 'yes'
+    WHEN a.x = 2 THEN 'no'
+    ELSE 'maybe'
+  END AS category
+FROM t a
+;

--- a/tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.input.sql
+++ b/tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.input.sql
@@ -1,0 +1,11 @@
+SELECT
+   a.short           AS key
+  ,a.much_longer_col AS label
+  ,a.no_alias
+  ,CASE
+    WHEN a.x = 1 THEN 'yes'
+    WHEN a.x = 2 THEN 'no'
+    ELSE 'maybe'
+  END AS category
+FROM t a
+;


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (Claude claude-sonnet-4-5) on behalf of @johnallen3d.

## Summary

Fixes a bug where column alias alignment was silently disabled for an entire `SELECT` list when any one aliased expression rendered as multi-line (e.g. a `CASE … END AS foo`). Simple single-line aliases in the same `SELECT` were left unpadded.

**Before:**
```sql
SELECT DISTINCT
   o.program_key
  ,o.offer_key
  ,o.offer_key AS key        -- ← no padding
  ,o.offer_label AS label    -- ← no padding
  ,o.calculator_key
  ...
  ,CASE
    WHEN si.offer_key IS NOT NULL THEN (...)
    WHEN ski.offer_key IS NOT NULL THEN ski.stacked_incentive
  END AS incentive
```

**After:**
```sql
SELECT DISTINCT
   o.program_key
  ,o.offer_key
  ,o.offer_key                    AS key     -- ← aligned
  ,o.offer_label                  AS label   -- ← aligned
  ,o.calculator_key
  ...
  ,CASE
    WHEN si.offer_key IS NOT NULL THEN (...)
    WHEN ski.offer_key IS NOT NULL THEN ski.stacked_incentive
  END AS incentive                           -- ← no padding (multi-line, correct)
```

## Changes

- `src/jarify/generator.py` — `_compute_as_align_width`: skip multi-line aliased expressions instead of aborting; return `None` only when fewer than 2 single-line aliases remain.
- `src/jarify/generator.py` — `alias_sql`: guard with `"\n" not in this_sql` so multi-line alias expressions never receive padding before their `AS` keyword.
- `tests/fixtures/conditionals/prefer_if_over_case.expected.sql` — updated to reflect correct alignment of `if()` aliases that co-exist with `CASE` aliases.
- `tests/fixtures/select/alias_alignment_mixed_multiline.{input,expected}.sql` — new fixture pair covering the bug.
- `tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.{input,expected}.sql` — idempotency counterpart.

Resolves #239
