### PR TITLE
fix(rules): emit if(cond, val, NULL) for no-ELSE CASE rewrites

### DIFF
--- a/src/jarify/rules/prefer_if_over_case.py
+++ b/src/jarify/rules/prefer_if_over_case.py
@@ -30,7 +30,7 @@ def _is_rewritable(node: exp.Case) -> bool:
 class PreferIfOverCaseRule(FormatterRule):
     """Format and lint: rewrite single-branch CASE WHEN … THEN … [ELSE …] END to IF().
 
-    DuckDB supports ``IF(condition, true_val[, false_val])`` as a first-class
+    DuckDB supports ``IF(condition, true_val, false_val)`` as a first-class
     function.  For searched CASE expressions with exactly one WHEN branch the
     IF form is shorter and more idiomatic.
 
@@ -40,9 +40,15 @@ class PreferIfOverCaseRule(FormatterRule):
     - Simple CASE (``CASE expr WHEN lit …``) is left unchanged.
     - CASE with 2+ WHEN branches is left unchanged.
 
+    **ELSE handling**: When the CASE has no ELSE clause the implicit return
+    value is ``NULL``.  The rewrite always emits the third argument explicitly
+    (``IF(cond, val, NULL)``) because DuckDB's ``IF()`` function requires
+    exactly three arguments — a two-argument call raises
+    ``Parser Error: Wrong number of arguments to IF``.
+
     **Format**: The ``apply()`` method rewrites matching ``exp.Case`` nodes to
     ``exp.If`` in-place.  The ``JarifyGenerator.if_sql()`` override then renders
-    ``exp.If`` as ``IF(cond, then[, else])`` instead of the default CASE WHEN form.
+    ``exp.If`` as ``IF(cond, then, else)`` instead of the default CASE WHEN form.
 
     **Lint**: The ``check()`` method flags any ``exp.Case`` node that matches the
     rewrite criteria but has not yet been formatted.
@@ -63,12 +69,15 @@ class PreferIfOverCaseRule(FormatterRule):
             if_branch = case.args["ifs"][0]
             condition = if_branch.args["this"]
             then_val = if_branch.args["true"]
-            else_val = case.args.get("default")  # None when there is no ELSE
+            # Use the explicit ELSE value, or NULL to satisfy DuckDB's
+            # requirement that IF() always takes exactly three arguments.
+            else_val = case.args.get("default")
+            false_arg = else_val.copy() if else_val is not None else exp.Null()
 
             replacement = exp.If(
                 this=condition.copy(),
                 true=then_val.copy(),
-                **({"false": else_val.copy()} if else_val is not None else {}),
+                false=false_arg,
             )
             case.replace(replacement)
 
@@ -86,7 +95,7 @@ class PreferIfOverCaseRule(FormatterRule):
                 LintViolation(
                     rule=self.name,
                     severity=self.severity,
-                    message=("Single-branch CASE WHEN … THEN … END can be rewritten as IF(cond, then[, else])"),
+                    message=("Single-branch CASE WHEN … THEN … END can be rewritten as IF(cond, then, else)"),
                     line=_line,
                     column=_col,
                 )

--- a/tests/fixtures/conditionals/prefer_if_no_else.expected.sql
+++ b/tests/fixtures/conditionals/prefer_if_no_else.expected.sql
@@ -1,0 +1,5 @@
+SELECT
+   MAX(if(context = 'numerator', divisor, NULL)) AS numerator_divisor
+  ,if(flag IS NULL, 'unknown', NULL)             AS flag_label
+FROM t
+;

--- a/tests/fixtures/conditionals/prefer_if_no_else.input.sql
+++ b/tests/fixtures/conditionals/prefer_if_no_else.input.sql
@@ -1,0 +1,4 @@
+SELECT
+  MAX(CASE WHEN context = 'numerator' THEN divisor END) AS numerator_divisor
+  , CASE WHEN flag IS NULL THEN 'unknown' END AS flag_label
+FROM t

--- a/tests/fixtures/conditionals/prefer_if_over_case.expected.sql
+++ b/tests/fixtures/conditionals/prefer_if_over_case.expected.sql
@@ -1,7 +1,7 @@
 SELECT
    a
   ,if(a > 1, 'big', 'small')   AS size
-  ,if(b IS NULL, 0)            AS b_or_zero
+  ,if(b IS NULL, 0, NULL)      AS b_or_zero
   ,if(status = 'active', 1, 0) AS is_active
   ,CASE
     WHEN a = 1 THEN 'one'


### PR DESCRIPTION
 > [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary

Fixes a bug where `CASE WHEN cond THEN val END` (no ELSE clause) was rewritten by `prefer-if-over-case` as `if(cond, val)` — a two-argument call that DuckDB rejects with:

```
Parser Error: Wrong number of arguments to IF.
```

DuckDB's `IF()` always requires exactly three arguments. The implicit return value of a no-ELSE CASE expression is `NULL`, so the fix supplies `exp.Null()` as the `false` argument when no ELSE is present, producing `if(cond, val, NULL)`.

## Changes

- `src/jarify/rules/prefer_if_over_case.py` — always set `false` on the `exp.If` replacement; use `exp.Null()` when the CASE has no ELSE clause; update docstring and lint message to reflect the change
- `tests/fixtures/conditionals/prefer_if_over_case.expected.sql` — update existing `if(b IS NULL, 0)` → `if(b IS NULL, 0, NULL)`
- `tests/fixtures/conditionals/prefer_if_no_else.{input,expected}.sql` — new fixture covering the exact reproduction case from the issue

Resolves #243
