### PR TITLE
fix: preserve json extract grouping before casts

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -559,6 +559,26 @@ FROM t
 
 ---
 
+### JSON extraction casts — preserve grouping
+
+When converting `CAST(json_expr->'path' AS type)` or `CAST(json_expr->>'path' AS type)` to DuckDB shorthand, keep parentheses around the extraction so the cast applies to the extracted value rather than the JSON path literal.
+
+**Bad**
+```sql
+SELECT j->'x'::STRUCT(a INTEGER), j->>'label'::TEXT FROM t
+```
+
+**Good**
+```sql
+SELECT
+   (j->'x')::STRUCT(a INTEGER)
+  ,(j->>'label')::TEXT
+FROM t
+;
+```
+
+---
+
 ### Struct literal — leading-comma style when multi-line
 
 When a positional struct literal `(val1, val2, ...)::my_struct` wraps across lines, the opening `(` appears on its own line and the fields use the same leading-comma style as `SELECT` lists.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -13,6 +13,7 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - IS NOT NULL preserved (not rewritten to NOT x IS NULL)
 - NULLS LAST/FIRST suppressed when it matches DuckDB's default
 - SELECT * FROM t → FROM t (DuckDB FROM-first syntax)
+- JSON extraction casts keep grouping: (json_expr->'path')::type
 - Struct tuple casts (val, ...)::type use leading-comma style when multi-line
 - DISTINCT inside aggregates appears on its own line when the call wraps
 - CREATE TABLE: opening paren on its own line, column name/type alignment,
@@ -1236,7 +1237,12 @@ class JarifyGenerator(DuckDB.Generator):
         if self.pretty and self.leading_comma and isinstance(expression.this, exp.Tuple):
             exprs_sql = self.expressions(expression.this, flat=False)
             return f"(\n{exprs_sql}\n)::{type_sql}"
-        return f"{self.sql(expression, 'this')}::{type_sql}"
+
+        value_sql = self.sql(expression, "this")
+        if isinstance(expression.this, (exp.JSONExtract, exp.JSONExtractScalar)):
+            value_sql = f"({value_sql})"
+
+        return f"{value_sql}::{type_sql}"
 
     # ------------------------------------------------------------------
     # Lambda: wrap body when the flat form exceeds max_line_length

--- a/tests/fixtures/duckdb/json_extract_cast_grouping.expected.sql
+++ b/tests/fixtures/duckdb/json_extract_cast_grouping.expected.sql
@@ -1,0 +1,5 @@
+SELECT
+   (j->'x')::struct(a int)
+  ,(j->>'label')::text
+FROM t
+;

--- a/tests/fixtures/duckdb/json_extract_cast_grouping.input.sql
+++ b/tests/fixtures/duckdb/json_extract_cast_grouping.input.sql
@@ -1,0 +1,1 @@
+SELECT CAST(j->'x' AS STRUCT(a INTEGER)), CAST(j->>'label' AS TEXT) FROM t

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -100,6 +100,13 @@ def test_wide_if_keeps_condition_compact_but_wraps_overlong_true_branch():
     assert "\n     ,NULL" in result
 
 
+def test_cast_wraps_json_extract_before_shorthand_cast():
+    sql = "SELECT CAST(j->'x' AS STRUCT(a INTEGER)), CAST(j->>'label' AS TEXT) FROM t"
+    result, _ = format_sql(sql)
+    assert "(j->'x')::struct(a int)" in result
+    assert "(j->>'label')::text" in result
+
+
 class TestFromFirst:
     def test_select_star_becomes_from_first(self):
         from jarify.formatter import format_sql


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi coding agent (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- preserve parentheses when lowering `CAST(json_expr->... AS type)` and `CAST(json_expr->>... AS type)` to `::type`
- add regression coverage in `tests/test_formatter.py` and a DuckDB fixture for JSON extraction casts
- document the grouping rule in `docs/sql-style-guide.md`

## Verification
- `mise run check`

Resolves #248
