### PR TITLE
fix(parser): preserve custom transform macros

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -74,7 +74,7 @@ WHERE a.active = true
 
 ### Functions — aggregate and window uppercase, scalar lowercase
 
-Aggregate and window functions (`COUNT`, `SUM`, `AVG`, `ROW_NUMBER`, `RANK`, `LEAD`, etc.) are always uppercase. All other DuckDB built-in functions (`regexp_extract`, `strftime`, `date_trunc`, etc.) remain lowercase.
+Aggregate and window functions (`COUNT`, `SUM`, `AVG`, `ROW_NUMBER`, `RANK`, `LEAD`, etc.) are always uppercase. All other DuckDB built-in functions (`regexp_extract`, `strftime`, `date_trunc`, etc.) remain lowercase. User-defined macro and function names are preserved and must not be rewritten to a different built-in name.
 
 **Bad**
 ```sql
@@ -90,6 +90,21 @@ SELECT
   ,regexp_extract(x, '[0-9]+')
   ,strftime(ts, '%Y')
 FROM t
+;
+```
+
+Custom macros keep their original name instead of being normalized to a built-in alias:
+
+**Bad**
+```sql
+SELECT list_transform(t, _transform) FROM txns
+```
+
+**Good**
+```sql
+SELECT
+   transform(t, _transform)
+FROM txns
 ;
 ```
 

--- a/src/jarify/parser.py
+++ b/src/jarify/parser.py
@@ -30,6 +30,12 @@ class _JarifyDuckDBParser(_DuckDB.Parser):
     TYPE_CONVERTERS: typing.ClassVar = {
         k: v for k, v in _DuckDB.Parser.TYPE_CONVERTERS.items() if k != _exp.DType.DECIMAL
     }
+    # sqlglot treats bare TRANSFORM(...) as DuckDB's list-transform function and
+    # rewrites it to LIST_TRANSFORM(...). DuckDB documents LIST_TRANSFORM and its
+    # explicit aliases, but not a bare TRANSFORM alias; projects may define their
+    # own `transform` macro. Remove the special-case parser entry so bare
+    # TRANSFORM(...) round-trips as an anonymous function call.
+    FUNCTIONS: typing.ClassVar = {k: v for k, v in _DuckDB.Parser.FUNCTIONS.items() if k != "TRANSFORM"}
 
 
 class _JarifyDuckDB(_DuckDB):

--- a/tests/fixtures/duckdb/transform_macro_preserved.expected.sql
+++ b/tests/fixtures/duckdb/transform_macro_preserved.expected.sql
@@ -1,0 +1,4 @@
+SELECT
+   transform(t, _transform) AS incentivized_amount
+FROM txns
+;

--- a/tests/fixtures/duckdb/transform_macro_preserved.input.sql
+++ b/tests/fixtures/duckdb/transform_macro_preserved.input.sql
@@ -1,0 +1,1 @@
+SELECT transform(t, _transform) AS incentivized_amount FROM txns

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -107,6 +107,13 @@ def test_cast_wraps_json_extract_before_shorthand_cast():
     assert "(j->>'label')::text" in result
 
 
+def test_transform_macro_is_not_rewritten_to_list_transform():
+    sql = "SELECT transform(t, _transform) AS incentivized_amount FROM txns"
+    result, _ = format_sql(sql)
+    assert "transform(t, _transform) AS incentivized_amount" in result
+    assert "list_transform" not in result
+
+
 class TestFromFirst:
     def test_select_star_becomes_from_first(self):
         from jarify.formatter import format_sql

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,6 +99,14 @@ class TestReservedKeywordTypeCasts:
         assert len(trees) == 1
         assert trees[0] is not None
 
+    def test_transform_macro_parses_as_anonymous_function(self) -> None:
+        sql = "SELECT transform(t, _transform)"
+        trees = parse_sql(sql)
+        assert len(trees) == 1
+        tree = trees[0]
+        assert tree is not None
+        assert tree.sql(dialect="duckdb") == "SELECT TRANSFORM(t, _transform)"
+
     def test_already_quoted_left_unchanged(self) -> None:
         """Already-quoted type names must not be double-quoted."""
         sql = 'SELECT []::"filter"[]'


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi coding agent (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- stop treating bare `TRANSFORM(...)` as DuckDB's `LIST_TRANSFORM(...)` during parsing
- preserve user-defined `transform` macros when formatting SQL
- add parser and formatter regression coverage, a fixture, and a style-guide note

## Verification
- `mise run check`

Resolves #249
