### PR TITLE
fix(rules): keep mixed agg group by explicit

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -944,7 +944,7 @@ QUALIFY
 
 ### `prefer-group-by-all`
 
-**Auto-fixed by `fmt`.** Rewrites explicit `GROUP BY col1, col2, ...` to `GROUP BY ALL` when all non-aggregated `SELECT` columns are listed.
+**Auto-fixed by `fmt`.** Rewrites explicit `GROUP BY col1, col2, ...` to `GROUP BY ALL` when every standalone non-aggregate `SELECT` expression is listed. Mixed aggregate/non-aggregate expressions stay explicit because DuckDB can reject `GROUP BY ALL` for that shape.
 
 **Bad**
 ```sql

--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -8,55 +8,23 @@ from jarify.rules.base import FormatterRule, _node_pos
 from jarify.types import LintViolation
 
 # DuckDB's list() aggregate is parsed by sqlglot as exp.List (Func, not AggFunc).
-# Treat it the same as AggFunc so it does not count as a free column reference.
+# Treat it the same as AggFunc when deciding whether a SELECT item is aggregate.
 _AGG_TYPES = (exp.AggFunc, exp.List)
 
 
-def _free_col_refs(expr: exp.Expression) -> set[str]:
-    """Return SQL strings of Column nodes in *expr* that are not inside any AggFunc.
-
-    For a purely non-aggregate expression like ``LOWER(name)`` this returns
-    ``{"name"}`` (the leaf column, not the whole expression).  Callers that
-    need the full expression SQL for purely non-aggregate items should call
-    ``expr.sql()`` directly instead.
-    """
-    if isinstance(expr, _AGG_TYPES):
-        return set()
-    if isinstance(expr, exp.Column):
-        return {expr.sql(dialect="duckdb")}
-    result: set[str] = set()
-    for child in expr.args.values():
-        if isinstance(child, list):
-            for c in child:
-                if isinstance(c, exp.Expression):
-                    result |= _free_col_refs(c)
-        elif isinstance(child, exp.Expression):
-            result |= _free_col_refs(child)
-    return result
-
-
 def _non_agg_sqls(select: exp.Select) -> set[str]:
-    """Derive the set of "non-aggregate expressions" that GROUP BY ALL would use.
+    """Return standalone non-aggregate SELECT expressions for GROUP BY ALL.
 
-    Rules:
-    - If a SELECT item contains **no** AggFunc anywhere, the whole item counts
-      as a GROUP BY candidate (e.g. ``LOWER(name)``, ``col1``).
-    - If a SELECT item is a **mixed** expression (contains an AggFunc *and*
-      free column references outside that AggFunc), those free column refs are
-      the GROUP BY candidates (e.g. ``'prefix' || col1 || STRING_AGG(x)``
-      contributes ``col1``).
-    - Pure aggregate items (e.g. ``SUM(col)`` with no outer column refs)
-      contribute nothing.
+    Mixed expressions like ``'prefix' || col1 || STRING_AGG(x)`` are excluded
+    even though they reference free columns, because DuckDB can reject
+    ``GROUP BY ALL`` for that shape with ``Cannot mix aggregates with
+    non-aggregated columns!``.
     """
     result: set[str] = set()
     for item in select.expressions:
         inner = item.this if isinstance(item, exp.Alias) else item
         if not inner.find(*_AGG_TYPES):
-            # Entirely non-aggregate — use the whole expression as-is.
             result.add(inner.sql(dialect="duckdb"))
-        else:
-            # Mixed or pure aggregate — collect free (non-agg) column refs.
-            result |= _free_col_refs(inner)
     return result
 
 

--- a/tests/fixtures/select/group_by_all_mixed_expr.expected.sql
+++ b/tests/fixtures/select/group_by_all_mixed_expr.expected.sql
@@ -1,5 +1,7 @@
 SELECT
    'prefix: ' || group_field || STRING_AGG(transaction_id, ', ') || group_key
 FROM t
-GROUP BY ALL
+GROUP BY
+   group_field
+  ,group_key
 ;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -248,6 +248,16 @@ class TestGroupByPerLine:
         out, _ = format_sql("SELECT a, b, count(*) FROM t GROUP BY ALL")
         assert "GROUP BY ALL" in out
 
+    def test_group_by_mixed_agg_expr_stays_explicit(self):
+        sql = (
+            "SELECT 'prefix: ' || group_field || string_agg(transaction_id, ', ') || "
+            "group_key FROM t GROUP BY group_field, group_key"
+        )
+        out, _ = format_sql(sql)
+        assert "GROUP BY ALL" not in out
+        assert "group_field" in out
+        assert "group_key" in out
+
     def test_group_by_single_column(self):
         out, _ = format_sql("SELECT a, count(*) FROM t GROUP BY a")
         assert "GROUP BY" in out

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -218,6 +218,14 @@ class TestPreferGroupByAll:
         rules = _lint(sql)
         assert "prefer-group-by-all" in rules
 
+    def test_no_warn_for_mixed_agg_expr(self):
+        sql = (
+            "SELECT 'prefix: ' || group_field || string_agg(transaction_id, ', ') || "
+            "group_key FROM t GROUP BY group_field, group_key"
+        )
+        rules = _lint(sql)
+        assert "prefer-group-by-all" not in rules
+
     def test_no_warn_when_list_agg_is_the_only_expr(self):
         # If every SELECT item is a list() aggregate there is no non-agg column
         # to group by, so the rule should not fire.


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- stop `prefer-group-by-all` from rewriting mixed aggregate/non-aggregate `SELECT` expressions to `GROUP BY ALL`
- keep regression coverage in formatter, lint, and fixture tests for the explicit `GROUP BY` form
- narrow the style guide wording to match DuckDB's actual binder behavior

## Verification
- `mise run check`

Resolves #250
