### PR TITLE
fix: preserve dynamic json_extract paths

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -616,6 +616,26 @@ FROM t
 
 ---
 
+### Dynamic JSON paths — keep function syntax
+
+Use `->` and `->>` only for static JSON paths. When the path is built from an expression such as `concat(...)`, preserve `json_extract(...)` / `json_extract_string(...)` so formatting does not change runtime behavior.
+
+**Bad**
+```sql
+SELECT to_json({'purchaser': ft.purchaser})->>concat('$.', o.group_by_field, '.', o.group_by_key) FROM offers o JOIN fact_transactions ft ON o.id = ft.offer_id
+```
+
+**Good**
+```sql
+SELECT
+   json_extract_string(to_json({'purchaser': ft.purchaser}), concat('$.', o.group_by_field, '.', o.group_by_key))
+FROM offers             o
+INNER JOIN fact_transactions ft ON o.id = ft.offer_id
+;
+```
+
+---
+
 ### Struct literal — leading-comma style when multi-line
 
 When a positional struct literal `(val1, val2, ...)::my_struct` wraps across lines, the opening `(` appears on its own line and the fields use the same leading-comma style as `SELECT` lists.

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -14,6 +14,7 @@ Subclasses sqlglot's DuckDBGenerator to enforce jarify's opinionated rules:
 - NULLS LAST/FIRST suppressed when it matches DuckDB's default
 - SELECT * FROM t → FROM t (DuckDB FROM-first syntax)
 - JSON extraction casts keep grouping: (json_expr->'path')::type
+- Dynamic JSON extraction paths stay as function calls; only static paths use -> / ->>
 - Struct tuple casts (val, ...)::type use leading-comma style when multi-line
 - DISTINCT inside aggregates appears on its own line when the call wraps
 - CREATE TABLE: opening paren on its own line, column name/type alignment,
@@ -1190,19 +1191,27 @@ class JarifyGenerator(DuckDB.Generator):
     # ------------------------------------------------------------------
     # -> / ->>: render without surrounding spaces (value->>'key' not value ->> 'key').
     # sqlglot's default binary() always adds " op " padding; we bypass it here.
-    # For simple single-key paths, also strip the $.  prefix that sqlglot adds
-    # during AST normalisation ($.offer_key → offer_key), matching DuckDB's
-    # short-form syntax.  Complex multi-segment paths keep their $. prefix.
+    # For static JSONPath expressions, also strip the $. prefix for simple
+    # root+key paths ($.offer_key → 'offer_key'), matching DuckDB's short form.
+    # Dynamic path expressions keep function-call syntax so formatter does not
+    # change runtime semantics by forcing them through the JSON operators.
     # ------------------------------------------------------------------
 
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
+        if not self._is_static_json_path(expression.expression):
+            return self.func("json_extract", expression.this, expression.expression)
         return f"{self.sql(expression, 'this')}->{self._json_path_sql(expression.expression)}"
 
     def jsonextractscalar_sql(self, expression: exp.JSONExtractScalar) -> str:
+        if not self._is_static_json_path(expression.expression):
+            return self.func("json_extract_string", expression.this, expression.expression)
         return f"{self.sql(expression, 'this')}->>{self._json_path_sql(expression.expression)}"
 
+    def _is_static_json_path(self, path_expr: exp.Expr) -> bool:
+        return isinstance(path_expr, exp.JSONPath)
+
     def _json_path_sql(self, path_expr: exp.Expr) -> str:
-        """Render a JSON path, using bare 'key' for simple root+key paths."""
+        """Render a static JSON path, using bare 'key' for simple root+key paths."""
         if (
             isinstance(path_expr, exp.JSONPath)
             and len(path_expr.expressions) == 2

--- a/tests/fixtures/select/json_extract_dynamic_path.expected.sql
+++ b/tests/fixtures/select/json_extract_dynamic_path.expected.sql
@@ -1,0 +1,4 @@
+SELECT
+   json_extract_string(j, concat('$.', field_name, '.', key_name))
+FROM t
+;

--- a/tests/fixtures/select/json_extract_dynamic_path.input.sql
+++ b/tests/fixtures/select/json_extract_dynamic_path.input.sql
@@ -1,0 +1,1 @@
+SELECT json_extract_string(j, concat('$.', field_name, '.', key_name)) FROM t

--- a/tests/fixtures/select/where_eq_alignment_nested_subquery.expected.sql
+++ b/tests/fixtures/select/where_eq_alignment_nested_subquery.expected.sql
@@ -6,5 +6,5 @@ FROM transactions        t
 INNER JOIN _sku_set_skus s USING (sku_key)
 WHERE t.transaction_type = s.transaction_type
   AND t.invoice_date BETWEEN s.start_date AND s.end_date
-  AND (group_by_value IS NULL OR (to_json({'purchaser': t.purchaser})->>(SELECT concat('$.', o.group_by[1].field, '.', o.group_by[1].key) FROM offers AS o WHERE o.offer_key = offer_key)) = group_by_value)
+  AND (group_by_value IS NULL OR (json_extract_string(to_json({'purchaser': t.purchaser}), (SELECT concat('$.', o.group_by[1].field, '.', o.group_by[1].key) FROM offers AS o WHERE o.offer_key = offer_key))) = group_by_value)
 ;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -107,6 +107,18 @@ def test_cast_wraps_json_extract_before_shorthand_cast():
     assert "(j->>'label')::text" in result
 
 
+def test_dynamic_json_extract_path_keeps_function_call_syntax():
+    sql = (
+        "SELECT json_extract_string("
+        "to_json(struct_pack(purchaser := ft.purchaser)), "
+        "concat('$.', o.group_by_field, '.', o.group_by_key)) "
+        "FROM offers o JOIN fact_transactions ft ON o.id = ft.offer_id"
+    )
+    result, _ = format_sql(sql)
+    assert "json_extract_string(" in result
+    assert "->>concat(" not in result
+
+
 def test_transform_macro_is_not_rewritten_to_list_transform():
     sql = "SELECT transform(t, _transform) AS incentivized_amount FROM txns"
     result, _ = format_sql(sql)


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi coding agent (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- preserve `json_extract(...)` and `json_extract_string(...)` for dynamic JSON path expressions
- keep `->` and `->>` formatting for static JSONPath literals
- add regression coverage and document the dynamic-path rule in the SQL style guide

## Testing
- `mise run check`

Resolves #252
