### PR TITLE
fix(generator): keep ORDER BY ALL inline

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -354,6 +354,39 @@ GROUP BY ALL
 
 ---
 
+### `ORDER BY` — one expression per line, except `ORDER BY ALL`
+
+Every explicit `ORDER BY` expression is on its own line using the same leading-comma style as `SELECT`. DuckDB's `ORDER BY ALL` shorthand is exempt and stays on one line.
+
+**Bad**
+```sql
+FROM data
+ORDER BY
+   ALL
+```
+
+**Good**
+```sql
+FROM data
+ORDER BY ALL
+;
+```
+
+Explicit sort keys still wrap one per line:
+
+```sql
+SELECT
+   a
+  ,b
+FROM data
+ORDER BY
+   a
+  ,b DESC
+;
+```
+
+---
+
 ### CTE layout
 
 The opening parenthesis goes on its own line. Each subsequent CTE is prefixed with a comma (no space between comma and name).

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -1210,7 +1210,7 @@ class JarifyGenerator(DuckDB.Generator):
         return f"VALUES\n{body}"
 
     # ------------------------------------------------------------------
-    # GROUP BY: one expression per line in pretty mode
+    # GROUP BY / ORDER BY ALL: keep ALL inline; otherwise one expression per line
     # ------------------------------------------------------------------
 
     def group_sql(self, expression: exp.Group) -> str:
@@ -1223,6 +1223,27 @@ class JarifyGenerator(DuckDB.Generator):
             expressions_sql = self.expressions(expression, flat=False)
             return f"{self.seg(f'GROUP BY{modifier}')}{self.sep() if expressions_sql else ''}{expressions_sql}"
         return super().group_sql(expression)
+
+    def order_sql(self, expression: exp.Order, flat: bool = False) -> str:
+        if self.pretty and self._is_order_by_all(expression):
+            return self.seg("ORDER BY ALL")
+        return super().order_sql(expression, flat=flat)
+
+    @staticmethod
+    def _is_order_by_all(expression: exp.Order) -> bool:
+        if expression.args.get("this") is not None or expression.args.get("siblings"):
+            return False
+        if len(expression.expressions) != 1:
+            return False
+
+        ordered = expression.expressions[0]
+        return (
+            isinstance(ordered, exp.Ordered)
+            and ordered.args.get("desc") is None
+            and ordered.args.get("with_fill") is None
+            and isinstance(ordered.this, exp.Var)
+            and ordered.this.name.upper() == "ALL"
+        )
 
     # ------------------------------------------------------------------
     # -> / ->>: render without surrounding spaces (value->>'key' not value ->> 'key').

--- a/tests/fixtures/select/order_by_all.expected.sql
+++ b/tests/fixtures/select/order_by_all.expected.sql
@@ -1,0 +1,3 @@
+FROM data
+ORDER BY ALL
+;

--- a/tests/fixtures/select/order_by_all.input.sql
+++ b/tests/fixtures/select/order_by_all.input.sql
@@ -1,0 +1,1 @@
+SELECT * FROM data ORDER BY ALL

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -332,6 +332,13 @@ class TestGroupByPerLine:
         assert "a" in out
 
 
+class TestOrderByAll:
+    def test_order_by_all_stays_inline(self):
+        out, _ = format_sql("SELECT * FROM data ORDER BY ALL")
+        assert "ORDER BY ALL" in out
+        assert "ORDER BY\n" not in out
+
+
 class TestTrailingRustFmtPlaceholder:
     """Trailing whole-line Rust format placeholders must land *before* the
     statement-terminating semicolon, not after it.


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- keep DuckDB `ORDER BY ALL` inline in pretty output
- preserve multi-line wrapping for explicit `ORDER BY` expressions
- add regression coverage and style-guide examples for `ORDER BY ALL`

## Testing
- `mise run check`

Resolves #267
