### PR TITLE
feat(formatter): align column aliases across query

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -525,7 +525,7 @@ CROSS JOIN UNNEST(o.vals) t(v)
 
 ### Column alias alignment
 
-When two or more columns in a `SELECT` list have aliases, the `AS` keyword is aligned to the widest column expression. Multi-line expressions still participate — the closing line (for example `END`) is padded so its trailing `AS` lines up with neighboring single-line aliases.
+When a query contains two or more column aliases anywhere in its `SELECT` lists, the `AS` keyword is aligned to the widest column expression across the full query. That includes outer queries, CTE bodies, and nested subqueries. Multi-line expressions still participate — the closing line (for example `END`) is padded so its trailing `AS` lines up with neighboring single-line aliases.
 
 **Bad**
 ```sql
@@ -551,6 +551,30 @@ SELECT
      ELSE NULL
    END        AS abc
 FROM data
+;
+```
+
+**Also good**
+```sql
+WITH _a AS
+(
+  SELECT
+     x   AS first
+    ,yy  AS second
+  FROM t
+)
+,_b AS
+(
+  SELECT
+     zzz AS third
+    ,w   AS fourth
+  FROM u
+)
+SELECT
+   q   AS fifth
+  ,rr  AS sixth
+FROM _a
+INNER JOIN _b ON 1 = 1
 ;
 ```
 

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -161,12 +161,22 @@ class JarifyGenerator(DuckDB.Generator):
         )
         self._config = config
         self._as_align_width: int | None = None  # set during SELECT expression rendering
+        self._tree_as_align_width: int | None = None  # set per statement tree during generate()
         self._col_name_align: int | None = None  # set during CREATE TABLE column rendering
         self._col_type_align: int | None = None  # set during CREATE TABLE column rendering
         self._join_alias_col: int | None = None  # set during FROM/JOIN block rendering
         self._leading_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
         self._trailing_sep_comment_texts: frozenset[str] = frozenset()  # set by formatter before generate()
         self._connector_force_expand: bool = False  # set True inside WHERE/HAVING to always break AND/OR
+
+    def generate(self, expression: exp.Expr, copy: bool = True) -> str:
+        saved_align = self._tree_as_align_width
+        if self.pretty:
+            self._tree_as_align_width = self._compute_tree_as_align_width(expression)
+        try:
+            return super().generate(expression, copy=copy)
+        finally:
+            self._tree_as_align_width = saved_align
 
     # ------------------------------------------------------------------
     # Function name casing: aggregates/window functions → UPPER, rest → lower
@@ -245,7 +255,7 @@ class JarifyGenerator(DuckDB.Generator):
         is_select = isinstance(expression, exp.Select) and key is None
         saved_align = self._as_align_width
         if is_select:
-            self._as_align_width = self._compute_as_align_width(list(expressions_list))
+            self._as_align_width = self._tree_as_align_width or self._compute_as_align_width(list(expressions_list))
 
         try:
             result_sqls = []
@@ -315,6 +325,27 @@ class JarifyGenerator(DuckDB.Generator):
         the trailing ``AS`` can align with single-line aliases in the same
         SELECT list.
         """
+        col_widths, alias_count = self._collect_as_alignment_metrics(expressions_list)
+        if alias_count < 2:
+            return None
+        return max(col_widths)
+
+    def _compute_tree_as_align_width(self, expression: exp.Expr) -> int | None:
+        """Compute one AS-alignment width across all SELECT lists in a statement tree."""
+        col_widths: list[int] = []
+        alias_count = 0
+        for select in expression.find_all(exp.Select):
+            widths, aliases = self._collect_as_alignment_metrics(list(select.expressions))
+            col_widths.extend(widths)
+            alias_count += aliases
+
+        if alias_count < 2 or not col_widths:
+            return None
+
+        return max(col_widths)
+
+    def _collect_as_alignment_metrics(self, expressions_list: list) -> tuple[list[int], int]:
+        """Return ``(column_widths, alias_count)`` for a SELECT expression list."""
         col_widths: list[int] = []
         alias_count = 0
         for e in expressions_list:
@@ -330,10 +361,7 @@ class JarifyGenerator(DuckDB.Generator):
                 if "\n" not in col_sql:
                     col_widths.append(len(col_sql))
 
-        if alias_count < 2:
-            return None
-
-        return max(col_widths)
+        return col_widths, alias_count
 
     # ------------------------------------------------------------------
     # Alias: align AS keyword when _as_align_width is set
@@ -583,7 +611,7 @@ class JarifyGenerator(DuckDB.Generator):
             return f" USING ({cols})"
         return ""
 
-    def _entry_alias_str(self, table_expr: exp.Expression) -> str:
+    def _entry_alias_str(self, table_expr: exp.Expr) -> str:
         """Return the rendered alias string for a FROM/JOIN entry (Table or Unnest)."""
         if isinstance(table_expr, exp.Table):
             return self._table_alias_str(table_expr)
@@ -592,7 +620,7 @@ class JarifyGenerator(DuckDB.Generator):
             return self.sql(alias_node) if alias_node else ""
         return ""
 
-    def _table_ref_only_sql(self, table_expr: exp.Expression) -> str | None:
+    def _table_ref_only_sql(self, table_expr: exp.Expr) -> str | None:
         """Return the table reference string (no alias) for simple tables and
         table-function calls (e.g. UNNEST), else None.
 
@@ -622,7 +650,7 @@ class JarifyGenerator(DuckDB.Generator):
         if not from_expr:
             return None
 
-        entries: list[tuple[int, str, exp.Expression]] = []
+        entries: list[tuple[int, str, exp.Expr]] = []
 
         from_ref = self._table_ref_only_sql(from_expr.this)
         if from_ref is None:

--- a/tests/fixtures/complex/real_world.expected.sql
+++ b/tests/fixtures/complex/real_world.expected.sql
@@ -7,7 +7,7 @@ SET VARIABLE time_frame = getenv('TIME_FRAME')
 WITH _latest_version AS
 (
   SELECT
-     regexp_extract(file, 'version=(.{21})', 1) AS version
+     regexp_extract(file, 'version=(.{21})', 1)  AS version
   FROM glob('s3://' || getvariable('tigris_bucket') || '/global-catalog/*/*')
   ORDER BY
      file DESC

--- a/tests/fixtures/select/alias_alignment_across_ctes.expected.sql
+++ b/tests/fixtures/select/alias_alignment_across_ctes.expected.sql
@@ -1,0 +1,20 @@
+WITH _a AS
+(
+  SELECT
+     x   AS first
+    ,yy  AS second
+  FROM t
+)
+,_b AS
+(
+  SELECT
+     zzz AS third
+    ,w   AS fourth
+  FROM u
+)
+SELECT
+   q   AS fifth
+  ,rr  AS sixth
+FROM _a
+INNER JOIN _b ON 1 = 1
+;

--- a/tests/fixtures/select/alias_alignment_across_ctes.input.sql
+++ b/tests/fixtures/select/alias_alignment_across_ctes.input.sql
@@ -1,0 +1,1 @@
+WITH a AS (SELECT x AS first, yy AS second FROM t), b AS (SELECT zzz AS third, w AS fourth FROM u) SELECT q AS fifth, rr AS sixth FROM a JOIN b ON 1 = 1

--- a/tests/fixtures/select/case_when_from_first_subquery.expected.sql
+++ b/tests/fixtures/select/case_when_from_first_subquery.expected.sql
@@ -2,7 +2,7 @@
 SELECT
    CASE _op
     WHEN 'variants' THEN (SELECT * FROM (SELECT unnest(_variants) AS variant))
-    WHEN 'filters'  THEN (SELECT * FROM (SELECT unnest(_filters) AS filter))
-  END AS result
+    WHEN 'filters'  THEN (SELECT * FROM (SELECT unnest(_filters)  AS filter))
+  END              AS result
 FROM t
 ;

--- a/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
@@ -10,6 +10,6 @@ WITH _sku_catalog AS
   {manufacturer_filter}
 )
 SELECT
-   skus::json AS skus
+   skus::json                  AS skus
 FROM _aggregated_and_sorted
 ;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -54,6 +54,22 @@ def test_as_alignment():
     assert len(set(as_positions)) == 1, f"AS keywords not aligned: {as_positions}"
 
 
+def test_as_alignment_spans_ctes_and_outer_select():
+    sql = (
+        "WITH a AS (SELECT x AS first, yy AS second FROM t), "
+        "b AS (SELECT zzz AS third, w AS fourth FROM u) "
+        "SELECT q AS fifth, rr AS sixth FROM a JOIN b ON 1 = 1"
+    )
+    result, _ = format_sql(sql)
+    alias_lines = [
+        line
+        for line in result.splitlines()
+        if any(f" AS {alias}" in line for alias in ("first", "second", "third", "fourth", "fifth", "sixth"))
+    ]
+    lhs_widths = [len(line.split(" AS ")[0].lstrip(" ,")) for line in alias_lines]
+    assert len(set(lhs_widths)) == 1, f"AS keywords not aligned across query: {lhs_widths}"
+
+
 def test_searched_case_issue_260_layout_is_preserved():
     sql = """SELECT
    foo_bar_baz AS xyz


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- align `AS` padding across all `SELECT` lists in a statement tree, including CTEs and nested subqueries
- add regression coverage with a new cross-CTE fixture and formatter test
- update existing snapshots and the SQL style guide to document query-wide alias alignment

## Testing
- `mise run check`

Resolves #264
