### PR TITLE
fix(cli): write unchanged stdin input to stdout

### DIFF
--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -88,6 +88,13 @@ def fmt(
             console.print(f"[yellow]WARN[/] {label}: {w}")
             any_changed = any_changed  # parse warnings → don't count as reformatted
 
+        if target_path is None and not check and not diff:
+            # stdin — always write SQL to stdout for pipeline-friendly behavior
+            click.echo(formatted if original != formatted else original, nl=False)
+            if original != formatted:
+                any_changed = True
+            continue
+
         if original == formatted:
             if not diff:
                 console.print(f"[dim]unchanged[/] {label}")
@@ -99,10 +106,8 @@ def fmt(
             _print_diff(label, original, formatted)
         elif check:
             console.print(f"[yellow]would reformat[/] {label}")
-        elif target_path is None:
-            # stdin — write formatted SQL to stdout
-            click.echo(formatted, nl=False)
         else:
+            assert target_path is not None
             target_path.write_text(formatted)
             console.print(f"[green]reformatted[/] {label}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+"""Tests for CLI behavior."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from jarify.cli import main
+
+
+def test_fmt_stdin_always_writes_sql_to_stdout_when_unchanged() -> None:
+    sql = "SELECT\n   1\n;\n"
+
+    result = CliRunner().invoke(main, ["fmt", "-"], input=sql, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert result.output == sql
+
+
+def test_fmt_file_reports_unchanged_when_input_is_file(tmp_path: Path) -> None:
+    sql_file = tmp_path / "query.sql"
+    sql_file.write_text("SELECT\n   1\n;\n")
+
+    result = CliRunner().invoke(main, ["fmt", str(sql_file)], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "unchanged" in result.output
+    assert str(sql_file) in result.output.replace("\n", "")


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- make `jarify fmt -` always emit SQL to `stdout` in normal mode, even when the input is already formatted
- keep file-based formatting behavior unchanged so files still report `unchanged` status text
- add CLI coverage for unchanged `stdin` and unchanged file input behavior

## Verification
- `uv run pytest tests/test_cli.py tests/test_config.py`
- `mise run check`

Resolves #271
