### PR TITLE
fix: keep alias alignment stable across nested ctes

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -525,7 +525,7 @@ CROSS JOIN UNNEST(o.vals) t(v)
 
 ### Column alias alignment
 
-When a query contains two or more column aliases anywhere in its `SELECT` lists, the `AS` keyword is aligned to the widest column expression across the full query. That includes outer queries, CTE bodies, and nested subqueries. Multi-line expressions still participate — the closing line (for example `END`) is padded so its trailing `AS` lines up with neighboring single-line aliases.
+When a query contains two or more column aliases anywhere in its query-wide `SELECT` lists, the `AS` keyword is aligned to one visible column across the full query. That includes the outer query plus CTE bodies, including nested CTEs, even when those `SELECT` lists are indented at different depths. Multi-line expressions still participate — the closing line (for example `END`) is padded so its trailing `AS` lines up with neighboring single-line aliases.
 
 **Bad**
 ```sql
@@ -575,6 +575,37 @@ SELECT
   ,rr  AS sixth
 FROM _a
 INNER JOIN _b ON 1 = 1
+;
+```
+
+**Also good**
+```sql
+WITH _outer_group AS
+(
+  WITH seed_group AS
+  (
+    SELECT
+       alpha_value       AS seed_one
+      ,beta_metric       AS seed_two
+    FROM source_a
+  )
+  SELECT
+     seed_one           AS outer_one
+    ,seed_two           AS outer_two
+  FROM seed_group
+)
+,_sibling_group AS
+(
+  SELECT
+     gamma_code         AS sibling_one
+    ,delta_indicator    AS sibling_two
+  FROM source_b
+)
+SELECT
+   outer_one           AS final_one
+  ,sibling_two         AS final_two
+FROM _outer_group
+INNER JOIN _sibling_group ON outer_one = sibling_one
 ;
 ```
 

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -161,7 +161,7 @@ class JarifyGenerator(DuckDB.Generator):
         )
         self._config = config
         self._as_align_width: int | None = None  # set during SELECT expression rendering
-        self._tree_as_align_width: int | None = None  # set per statement tree during generate()
+        self._tree_as_align_column: int | None = None  # visible AS column target per statement tree during generate()
         self._col_name_align: int | None = None  # set during CREATE TABLE column rendering
         self._col_type_align: int | None = None  # set during CREATE TABLE column rendering
         self._join_alias_col: int | None = None  # set during FROM/JOIN block rendering
@@ -170,13 +170,13 @@ class JarifyGenerator(DuckDB.Generator):
         self._connector_force_expand: bool = False  # set True inside WHERE/HAVING to always break AND/OR
 
     def generate(self, expression: exp.Expr, copy: bool = True) -> str:
-        saved_align = self._tree_as_align_width
+        saved_align = self._tree_as_align_column
         if self.pretty:
-            self._tree_as_align_width = self._compute_tree_as_align_width(expression)
+            self._tree_as_align_column = self._compute_tree_as_align_column(expression)
         try:
             return super().generate(expression, copy=copy)
         finally:
-            self._tree_as_align_width = saved_align
+            self._tree_as_align_column = saved_align
 
     # ------------------------------------------------------------------
     # Function name casing: aggregates/window functions → UPPER, rest → lower
@@ -255,7 +255,13 @@ class JarifyGenerator(DuckDB.Generator):
         is_select = isinstance(expression, exp.Select) and key is None
         saved_align = self._as_align_width
         if is_select:
-            self._as_align_width = self._tree_as_align_width or self._compute_as_align_width(list(expressions_list))
+            select_expression = t.cast(exp.Select, expression)
+            prefix_width = self._select_expression_prefix_width(select_expression)
+            self._as_align_width = (
+                self._tree_as_align_column - prefix_width
+                if self._tree_as_align_column is not None
+                else self._compute_as_align_width(list(expressions_list))
+            )
 
         try:
             result_sqls = []
@@ -330,19 +336,51 @@ class JarifyGenerator(DuckDB.Generator):
             return None
         return max(col_widths)
 
-    def _compute_tree_as_align_width(self, expression: exp.Expr) -> int | None:
-        """Compute one AS-alignment width across all SELECT lists in a statement tree."""
-        col_widths: list[int] = []
+    def _compute_tree_as_align_column(self, expression: exp.Expr) -> int | None:
+        """Compute one visible AS column across the query-wide CTE/select tree."""
+        as_columns: list[int] = []
         alias_count = 0
-        for select in expression.find_all(exp.Select):
+        for select in self._iter_query_aligned_selects(expression):
             widths, aliases = self._collect_as_alignment_metrics(list(select.expressions))
-            col_widths.extend(widths)
+            prefix_width = self._select_expression_prefix_width(select)
+            as_columns.extend(prefix_width + width for width in widths)
             alias_count += aliases
 
-        if alias_count < 2 or not col_widths:
+        if alias_count < 2 or not as_columns:
             return None
 
-        return max(col_widths)
+        return max(as_columns)
+
+    def _iter_query_aligned_selects(self, expression: exp.Expr) -> t.Iterator[exp.Select]:
+        """Yield SELECTs that share query-wide alias alignment.
+
+        Query-wide alignment spans the main SELECT plus any CTE-body SELECTs,
+        including nested CTEs. It intentionally excludes unrelated subqueries in
+        expressions or JOINs, which keep their local alignment behavior.
+        """
+        if isinstance(expression, exp.Select):
+            yield expression
+            with_ = expression.args.get("with_")
+            if isinstance(with_, exp.With):
+                for cte in with_.expressions:
+                    if isinstance(cte, exp.CTE) and isinstance(cte.this, exp.Select):
+                        yield from self._iter_query_aligned_selects(cte.this)
+
+    def _select_expression_prefix_width(self, select: exp.Select) -> int:
+        """Return visible prefix width before a SELECT-list expression.
+
+        In pretty mode, each expression line gets the generator pad plus the
+        leading-comma marker (` ` for the first row, `,` for subsequent rows).
+        Every ancestor SELECT adds one more indent level around the nested
+        statement, so nested CTEs/subqueries shift the visible `AS` column.
+        """
+        ancestor_selects = 0
+        parent = select.parent
+        while parent is not None:
+            if isinstance(parent, exp.Select):
+                ancestor_selects += 1
+            parent = parent.parent
+        return self.pad + 1 + (ancestor_selects * self._indent)
 
     def _collect_as_alignment_metrics(self, expressions_list: list) -> tuple[list[int], int]:
         """Return ``(column_widths, alias_count)`` for a SELECT expression list."""

--- a/tests/fixtures/complex/real_world.expected.sql
+++ b/tests/fixtures/complex/real_world.expected.sql
@@ -7,7 +7,7 @@ SET VARIABLE time_frame = getenv('TIME_FRAME')
 WITH _latest_version AS
 (
   SELECT
-     regexp_extract(file, 'version=(.{21})', 1)  AS version
+     regexp_extract(file, 'version=(.{21})', 1) AS version
   FROM glob('s3://' || getvariable('tigris_bucket') || '/global-catalog/*/*')
   ORDER BY
      file DESC
@@ -61,7 +61,7 @@ SELECT
   ,p.program_redemption_price
   ,p.origin
   ,all_e.participant_key
-  ,if(e.participant_key IS NOT NULL, 'Y', 'N') AS enrolled
+  ,if(e.participant_key IS NOT NULL, 'Y', 'N')  AS enrolled
   ,sc.version
 FROM _relevant_skus rs
 INNER JOIN _sku_catalog sc ON sc.sku_key = rs.sku_key AND sc.manufacturer_key = rs.program_supplier_key

--- a/tests/fixtures/select/alias_alignment_across_ctes.expected.sql
+++ b/tests/fixtures/select/alias_alignment_across_ctes.expected.sql
@@ -13,8 +13,8 @@ WITH _a AS
   FROM u
 )
 SELECT
-   q   AS fifth
-  ,rr  AS sixth
+   q     AS fifth
+  ,rr    AS sixth
 FROM _a
 INNER JOIN _b ON 1 = 1
 ;

--- a/tests/fixtures/select/alias_alignment_nested_ctes.expected.sql
+++ b/tests/fixtures/select/alias_alignment_nested_ctes.expected.sql
@@ -1,0 +1,27 @@
+WITH _outer_group AS
+(
+  WITH seed_group AS
+  (
+    SELECT
+       alpha_value   AS seed_one
+      ,beta_metric   AS seed_two
+    FROM source_a
+  )
+  SELECT
+     seed_one        AS outer_one
+    ,seed_two        AS outer_two
+  FROM seed_group
+)
+,_sibling_group AS
+(
+  SELECT
+     gamma_code      AS sibling_one
+    ,delta_indicator AS sibling_two
+  FROM source_b
+)
+SELECT
+   outer_one         AS final_one
+  ,sibling_two       AS final_two
+FROM _outer_group
+INNER JOIN _sibling_group ON outer_one = sibling_one
+;

--- a/tests/fixtures/select/alias_alignment_nested_ctes.input.sql
+++ b/tests/fixtures/select/alias_alignment_nested_ctes.input.sql
@@ -1,0 +1,12 @@
+WITH outer_group AS (
+  WITH seed_group AS (
+    SELECT alpha_value AS seed_one, beta_metric AS seed_two FROM source_a
+  )
+  SELECT seed_one AS outer_one, seed_two AS outer_two FROM seed_group
+),
+sibling_group AS (
+  SELECT gamma_code AS sibling_one, delta_indicator AS sibling_two FROM source_b
+)
+SELECT outer_one AS final_one, sibling_two AS final_two
+FROM outer_group
+JOIN sibling_group ON outer_one = sibling_one

--- a/tests/fixtures/select/case_when_from_first_subquery.expected.sql
+++ b/tests/fixtures/select/case_when_from_first_subquery.expected.sql
@@ -2,7 +2,7 @@
 SELECT
    CASE _op
     WHEN 'variants' THEN (SELECT * FROM (SELECT unnest(_variants) AS variant))
-    WHEN 'filters'  THEN (SELECT * FROM (SELECT unnest(_filters)  AS filter))
-  END              AS result
+    WHEN 'filters'  THEN (SELECT * FROM (SELECT unnest(_filters) AS filter))
+  END AS result
 FROM t
 ;

--- a/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
@@ -10,6 +10,6 @@ WITH _sku_catalog AS
   {manufacturer_filter}
 )
 SELECT
-   skus::json                  AS skus
+   skus::json                    AS skus
 FROM _aggregated_and_sorted
 ;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -66,8 +66,44 @@ def test_as_alignment_spans_ctes_and_outer_select():
         for line in result.splitlines()
         if any(f" AS {alias}" in line for alias in ("first", "second", "third", "fourth", "fifth", "sixth"))
     ]
-    lhs_widths = [len(line.split(" AS ")[0].lstrip(" ,")) for line in alias_lines]
-    assert len(set(lhs_widths)) == 1, f"AS keywords not aligned across query: {lhs_widths}"
+    as_positions = [line.index(" AS ") for line in alias_lines]
+    assert len(set(as_positions)) == 1, f"AS keywords not aligned across query: {as_positions}"
+
+
+def test_as_alignment_stays_visually_consistent_across_nested_ctes():
+    sql = (
+        "WITH outer_group AS ("
+        "  WITH seed_group AS ("
+        "    SELECT alpha_value AS seed_one, beta_metric AS seed_two FROM source_a"
+        "  )"
+        "  SELECT seed_one AS outer_one, seed_two AS outer_two FROM seed_group"
+        "), "
+        "sibling_group AS ("
+        "  SELECT gamma_code AS sibling_one, delta_indicator AS sibling_two FROM source_b"
+        ") "
+        "SELECT outer_one AS final_one, sibling_two AS final_two "
+        "FROM outer_group JOIN sibling_group ON outer_one = sibling_one"
+    )
+    result, _ = format_sql(sql)
+    alias_lines = [
+        line
+        for line in result.splitlines()
+        if any(
+            f" AS {alias}" in line
+            for alias in (
+                "seed_one",
+                "seed_two",
+                "outer_one",
+                "outer_two",
+                "sibling_one",
+                "sibling_two",
+                "final_one",
+                "final_two",
+            )
+        )
+    ]
+    as_positions = [line.index(" AS ") for line in alias_lines]
+    assert len(set(as_positions)) == 1, f"Nested CTE alias alignment drifted: {as_positions}"
 
 
 def test_searched_case_issue_260_layout_is_preserved():


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- keep query-wide alias alignment anchored to one visible `AS` column across the outer query and CTE bodies
- add regression coverage for nested CTE alias alignment drift
- update affected formatter fixtures and the style guide examples

## Testing
- `mise run check`

Resolves #276
