### PR TITLE
feat(rules): add comment-based rule overrides

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -1013,6 +1013,39 @@ FROM _lookup
 
 Rules in this section may lint only, auto-fix during `fmt`, or do both. All rules default to `warn`. Severity can be set to `off`, `warn`, or `error` in `jarify.toml`.
 
+### Comment overrides
+
+Use `jarify` comment directives when one line or region needs an exception without changing repo-wide config.
+
+Supported directives:
+
+- `-- jarify: disable-line <rule>` — disable a rule on the current line
+- `-- jarify: disable-next-line <rule>` — disable a rule on the following line
+- `-- jarify: disable <rule>` / `-- jarify: enable <rule>` — disable a rule for a region
+- `-- jarify: disable-file <rule>` — disable a rule for the whole file
+- `-- jarify: set max_line_length = 140` / `-- jarify: reset max_line_length` — override line length for following statements until reset
+
+Rules use their lint names such as `no-select-star`, `cte-naming`, or `prefer-if-over-case`.
+
+**Example**
+```sql
+-- jarify: disable-next-line prefer-if-over-case
+SELECT CASE WHEN is_large THEN 'big' ELSE 'small' END FROM sizes
+```
+
+**Good output**
+```sql
+-- jarify: disable-next-line prefer-if-over-case
+SELECT
+   CASE
+     WHEN is_large
+     THEN 'big'
+     ELSE 'small'
+   END
+FROM sizes
+;
+```
+
 ---
 
 ### `no-select-star`

--- a/src/jarify/comment_overrides.py
+++ b/src/jarify/comment_overrides.py
@@ -1,0 +1,194 @@
+"""Parse comment-based rule overrides for linting and formatting."""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from collections import defaultdict
+from typing import Any
+
+from jarify.config import JarifyConfig
+
+RULE_ALIASES: dict[str, str] = {
+    "keyword-case": "keyword-case",
+    "trailing-commas": "trailing-commas",
+    "no-implicit-cross-join": "no-implicit-cross-join",
+    "no-select-star": "no-select-star",
+    "no-unused-cte": "no-unused-cte",
+    "duckdb-type-style": "duckdb-type-style",
+    "duckdb-prefer-qualify": "duckdb-prefer-qualify",
+    "cte-naming": "cte-naming",
+    "prefer-group-by-all": "prefer-group-by-all",
+    "prefer-using-over-on": "prefer-using-over-on",
+    "consistent-empty-array": "consistent-empty-array",
+    "no-select-star-in-cte": "no-select-star-in-cte",
+    "prefer-neq-operator": "prefer-neq-operator",
+    "prefer-if-over-case": "prefer-if-over-case",
+    "parse-error": "parse-error",
+    "all": "all",
+}
+
+SETTING_ALIASES: dict[str, str] = {
+    "max-line-length": "max_line_length",
+    "line-length": "max_line_length",
+    "max_line_length": "max_line_length",
+}
+
+_DIRECTIVE_RE = re.compile(r"jarify:\s*(.+)", re.IGNORECASE)
+_RANGE_END = 10**9
+
+
+@dataclasses.dataclass(frozen=True)
+class _RuleRange:
+    start: int
+    end: int
+    rule: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _SettingRange:
+    start: int
+    end: int
+    name: str
+    value: Any
+
+
+@dataclasses.dataclass(frozen=True)
+class CommentOverrides:
+    """Comment-driven overrides resolved to line-aware lookups."""
+
+    file_disabled_rules: frozenset[str] = frozenset()
+    line_disabled_rules: dict[int, frozenset[str]] = dataclasses.field(default_factory=dict)
+    rule_ranges: tuple[_RuleRange, ...] = ()
+    setting_ranges: tuple[_SettingRange, ...] = ()
+
+    def is_rule_disabled(self, rule: str, line: int | None) -> bool:
+        normalized = normalize_rule_name(rule)
+        if normalized in self.file_disabled_rules or "all" in self.file_disabled_rules:
+            return True
+        if line is None:
+            return False
+        line_rules = self.line_disabled_rules.get(line, frozenset())
+        if normalized in line_rules or "all" in line_rules:
+            return True
+        return any(rng.rule in {normalized, "all"} and rng.start <= line <= rng.end for rng in self.rule_ranges)
+
+    def config_for_line(self, config: JarifyConfig, line: int | None) -> JarifyConfig:
+        if line is None:
+            return config
+        updates: dict[str, Any] = {}
+        for rng in self.setting_ranges:
+            if rng.start <= line <= rng.end:
+                updates[rng.name] = rng.value
+        return dataclasses.replace(config, **updates) if updates else config
+
+
+@dataclasses.dataclass
+class _ParsedDirective:
+    kind: str
+    args: str
+
+
+def normalize_rule_name(name: str) -> str:
+    normalized = name.strip().lower().replace("_", "-")
+    return RULE_ALIASES.get(normalized, normalized)
+
+
+def normalize_setting_name(name: str) -> str:
+    normalized = name.strip().lower().replace("-", "_")
+    return SETTING_ALIASES.get(normalized, normalized)
+
+
+def parse_comment_overrides(sql: str) -> CommentOverrides:
+    """Return parsed comment directives from raw SQL text."""
+
+    file_disabled_rules: set[str] = set()
+    line_disabled_rules: dict[int, set[str]] = defaultdict(set)
+    rule_ranges: list[_RuleRange] = []
+    setting_ranges: list[_SettingRange] = []
+
+    open_rule_ranges: dict[str, int] = {}
+    open_setting_ranges: dict[str, tuple[int, Any]] = {}
+
+    for line_no, raw_line in enumerate(sql.splitlines(), start=1):
+        directive = _parse_directive(raw_line)
+        if directive is None:
+            continue
+
+        if directive.kind == "disable-file":
+            for rule in _parse_rules(directive.args):
+                file_disabled_rules.add(rule)
+            continue
+
+        if directive.kind == "disable-line":
+            for rule in _parse_rules(directive.args):
+                line_disabled_rules[line_no].add(rule)
+            continue
+
+        if directive.kind == "disable-next-line":
+            for rule in _parse_rules(directive.args):
+                line_disabled_rules[line_no + 1].add(rule)
+            continue
+
+        if directive.kind == "disable":
+            start = line_no + 1
+            for rule in _parse_rules(directive.args):
+                open_rule_ranges.setdefault(rule, start)
+            continue
+
+        if directive.kind == "enable":
+            for rule in _parse_rules(directive.args):
+                if rule in open_rule_ranges:
+                    rule_ranges.append(_RuleRange(open_rule_ranges.pop(rule), line_no - 1, rule))
+            continue
+
+        if directive.kind == "set":
+            name, value = _parse_setting(directive.args)
+            if name is None:
+                continue
+            open_setting_ranges[name] = (line_no + 1, value)
+            continue
+
+        if directive.kind == "reset":
+            name = normalize_setting_name(directive.args)
+            if name in open_setting_ranges:
+                start, value = open_setting_ranges.pop(name)
+                setting_ranges.append(_SettingRange(start, line_no - 1, name, value))
+
+    for rule, start in open_rule_ranges.items():
+        rule_ranges.append(_RuleRange(start, _RANGE_END, rule))
+    for name, (start, value) in open_setting_ranges.items():
+        setting_ranges.append(_SettingRange(start, _RANGE_END, name, value))
+
+    frozen_lines = {line: frozenset(rules) for line, rules in line_disabled_rules.items()}
+    return CommentOverrides(
+        file_disabled_rules=frozenset(file_disabled_rules),
+        line_disabled_rules=frozen_lines,
+        rule_ranges=tuple(rule_ranges),
+        setting_ranges=tuple(setting_ranges),
+    )
+
+
+def _parse_directive(line: str) -> _ParsedDirective | None:
+    match = _DIRECTIVE_RE.search(line)
+    if not match:
+        return None
+    body = match.group(1).strip().rstrip("*/ ")
+    for kind in ("disable-file", "disable-next-line", "disable-line", "disable", "enable", "set", "reset"):
+        if body.lower().startswith(kind):
+            return _ParsedDirective(kind=kind, args=body[len(kind) :].strip())
+    return None
+
+
+def _parse_rules(args: str) -> list[str]:
+    return [normalize_rule_name(part) for part in re.split(r"[\s,]+", args) if part.strip()]
+
+
+def _parse_setting(args: str) -> tuple[str | None, Any]:
+    if "=" not in args:
+        return None, None
+    raw_name, raw_value = [part.strip() for part in args.split("=", 1)]
+    name = normalize_setting_name(raw_name)
+    if name == "max_line_length":
+        return name, int(raw_value)
+    return name, raw_value

--- a/src/jarify/comment_overrides.py
+++ b/src/jarify/comment_overrides.py
@@ -99,6 +99,23 @@ def normalize_setting_name(name: str) -> str:
     return SETTING_ALIASES.get(normalized, normalized)
 
 
+def _stmt_end_line(lines: list[str], after_line_no: int) -> int:
+    """Return the 1-indexed line number of the end of the SQL statement that
+    starts on or after *after_line_no* (1-indexed).
+
+    Scans forward for the first line that ends with a bare ``;`` (the jarify
+    canonical terminator) or for end-of-file.  Block comments and directive
+    comments are skipped so a ``;`` inside a comment does not terminate early.
+    """
+    for i in range(after_line_no, len(lines)):  # 0-indexed
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        if stripped == ";" or stripped.endswith(";"):
+            return i + 1  # convert to 1-indexed
+    return len(lines)
+
+
 def parse_comment_overrides(sql: str) -> CommentOverrides:
     """Return parsed comment directives from raw SQL text."""
 
@@ -110,7 +127,8 @@ def parse_comment_overrides(sql: str) -> CommentOverrides:
     open_rule_ranges: dict[str, int] = {}
     open_setting_ranges: dict[str, tuple[int, Any]] = {}
 
-    for line_no, raw_line in enumerate(sql.splitlines(), start=1):
+    lines = sql.splitlines()
+    for line_no, raw_line in enumerate(lines, start=1):
         directive = _parse_directive(raw_line)
         if directive is None:
             continue
@@ -126,8 +144,9 @@ def parse_comment_overrides(sql: str) -> CommentOverrides:
             continue
 
         if directive.kind == "disable-next-line":
+            stmt_end = _stmt_end_line(lines, line_no)  # line_no is 1-indexed; lines is 0-indexed
             for rule in _parse_rules(directive.args):
-                line_disabled_rules[line_no + 1].add(rule)
+                rule_ranges.append(_RuleRange(line_no + 1, stmt_end, rule))
             continue
 
         if directive.kind == "disable":

--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -8,6 +8,7 @@ from sqlglot.errors import ParseError
 from sqlglot.expressions import Expression
 from sqlglot.tokens import Tokenizer as SqlglotTokenizer
 
+from jarify.comment_overrides import parse_comment_overrides
 from jarify.config import JarifyConfig
 from jarify.generator import JarifyGenerator
 from jarify.parser import (
@@ -24,7 +25,7 @@ from jarify.parser import (
     parse_sql,
 )
 from jarify.rules import get_default_rules
-from jarify.rules.base import FormatterRule
+from jarify.rules.base import FormatterRule, _node_pos
 
 
 class FormatWarning:
@@ -49,6 +50,7 @@ def format_sql(
     """
     config = config or JarifyConfig()
     warnings: list[FormatWarning] = []
+    overrides = parse_comment_overrides(sql)
 
     # Pre-process: replace whole-line placeholders used as CTAS bodies (those
     # following a line that ends with AS) with a dummy SELECT so sqlglot
@@ -76,16 +78,20 @@ def format_sql(
         warnings.append(FormatWarning(f"could not parse SQL (formatting skipped): {exc}"))
         return sql, warnings
 
-    rules = get_default_rules(config)
-    generator = JarifyGenerator(config)
-    generator._leading_comment_texts = _find_leading_comment_texts(masked_sql)
-    generator._trailing_sep_comment_texts = _find_trailing_sep_comment_texts(masked_sql)
+    rules = get_default_rules(config, overrides=overrides)
+    leading_comment_texts = _find_leading_comment_texts(masked_sql)
+    trailing_sep_comment_texts = _find_trailing_sep_comment_texts(masked_sql)
     formatted_parts: list[str] = []
 
     for tree in trees:
         if tree is None:
             continue
         tree = _apply_rules(tree, rules)
+        tree_line, _ = _node_pos(tree)
+        tree_config = overrides.config_for_line(config, tree_line)
+        generator = JarifyGenerator(tree_config)
+        generator._leading_comment_texts = leading_comment_texts
+        generator._trailing_sep_comment_texts = trailing_sep_comment_texts
         formatted_parts.append(generator.generate(tree))
 
     # Join statements but hold off on the trailing ;\n -- it must come *after*

--- a/src/jarify/linter.py
+++ b/src/jarify/linter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jarify.comment_overrides import parse_comment_overrides
 from jarify.config import JarifyConfig
 from jarify.parser import _mask_rust_fmt_placeholders, parse_sql_lenient
 from jarify.rules import get_default_rules
@@ -13,14 +14,16 @@ __all__ = ["LintViolation", "lint_sql"]
 def lint_sql(sql: str, config: JarifyConfig | None = None) -> list[LintViolation]:
     """Lint a SQL string and return a list of violations."""
     config = config or JarifyConfig()
+    overrides = parse_comment_overrides(sql)
     masked_sql, _ = _mask_rust_fmt_placeholders(sql)
     trees, parse_errors = parse_sql_lenient(masked_sql, dialect=config.dialect)
     violations: list[LintViolation] = []
 
     for err in parse_errors:
-        violations.append(LintViolation(rule="parse-error", message=str(err), severity="error"))
+        if not overrides.is_rule_disabled("parse-error", None):
+            violations.append(LintViolation(rule="parse-error", message=str(err), severity="error"))
 
-    rules = get_default_rules(config)
+    rules = get_default_rules(config, overrides=overrides)
     for tree in trees:
         if tree is None:
             continue

--- a/src/jarify/rules/__init__.py
+++ b/src/jarify/rules/__init__.py
@@ -21,10 +21,11 @@ from jarify.rules.prefer_using_over_on import PreferUsingOverOnRule
 from jarify.rules.trailing_commas import TrailingCommasRule
 
 if TYPE_CHECKING:
+    from jarify.comment_overrides import CommentOverrides
     from jarify.config import JarifyConfig
 
 
-def get_default_rules(config: JarifyConfig) -> list[FormatterRule]:
+def get_default_rules(config: JarifyConfig, overrides: CommentOverrides | None = None) -> list[FormatterRule]:
     """Return the full rule set based on the given config.
 
     Rules are ordered: format-transforming rules run before lint-only rules.
@@ -33,36 +34,42 @@ def get_default_rules(config: JarifyConfig) -> list[FormatterRule]:
 
     # --- Formatting rules (AST transformers) ---
     if config.uppercase_keywords:
-        rules.append(KeywordCaseRule(uppercase=True))
+        rules.append(KeywordCaseRule(uppercase=True, overrides=overrides))
     if config.trailing_commas and not config.leading_commas:
-        rules.append(TrailingCommasRule())
+        rules.append(TrailingCommasRule(overrides=overrides))
     if config.no_implicit_cross_join != "off":
-        rules.append(NoImplicitCrossJoinRule(severity=config.no_implicit_cross_join))
+        rules.append(NoImplicitCrossJoinRule(severity=config.no_implicit_cross_join, overrides=overrides))
 
     # --- General lint rules (checkers, no AST mutation) ---
     if config.no_select_star != "off":
-        rules.append(NoSelectStarRule(severity=config.no_select_star, prefer_from_first=config.prefer_from_first))
+        rules.append(
+            NoSelectStarRule(
+                severity=config.no_select_star,
+                prefer_from_first=config.prefer_from_first,
+                overrides=overrides,
+            )
+        )
     if config.no_unused_cte != "off":
-        rules.append(NoUnusedCteRule(severity=config.no_unused_cte))
+        rules.append(NoUnusedCteRule(severity=config.no_unused_cte, overrides=overrides))
 
     # --- DuckDB-specific lint rules ---
     if config.duckdb_type_style != "off":
-        rules.append(DuckdbTypeStyleRule(severity=config.duckdb_type_style))
+        rules.append(DuckdbTypeStyleRule(severity=config.duckdb_type_style, overrides=overrides))
     if config.duckdb_prefer_qualify != "off":
-        rules.append(DuckdbPreferQualifyRule(severity=config.duckdb_prefer_qualify))
+        rules.append(DuckdbPreferQualifyRule(severity=config.duckdb_prefer_qualify, overrides=overrides))
     if config.cte_naming != "off":
-        rules.append(CteNamingRule(severity=config.cte_naming))
+        rules.append(CteNamingRule(severity=config.cte_naming, overrides=overrides))
     if config.prefer_group_by_all != "off":
-        rules.append(PreferGroupByAllRule(severity=config.prefer_group_by_all))
+        rules.append(PreferGroupByAllRule(severity=config.prefer_group_by_all, overrides=overrides))
     if config.prefer_using_over_on != "off":
-        rules.append(PreferUsingOverOnRule(severity=config.prefer_using_over_on))
+        rules.append(PreferUsingOverOnRule(severity=config.prefer_using_over_on, overrides=overrides))
     if config.consistent_empty_array != "off":
-        rules.append(ConsistentEmptyArrayRule(severity=config.consistent_empty_array))
+        rules.append(ConsistentEmptyArrayRule(severity=config.consistent_empty_array, overrides=overrides))
     if config.no_select_star_in_cte != "off":
-        rules.append(NoSelectStarInCteRule(severity=config.no_select_star_in_cte))
+        rules.append(NoSelectStarInCteRule(severity=config.no_select_star_in_cte, overrides=overrides))
     if config.prefer_neq_operator != "off":
-        rules.append(PreferNeqOperatorRule(severity=config.prefer_neq_operator))
+        rules.append(PreferNeqOperatorRule(severity=config.prefer_neq_operator, overrides=overrides))
     if config.prefer_if_over_case != "off":
-        rules.append(PreferIfOverCaseRule(severity=config.prefer_if_over_case))
+        rules.append(PreferIfOverCaseRule(severity=config.prefer_if_over_case, overrides=overrides))
 
     return rules

--- a/src/jarify/rules/base.py
+++ b/src/jarify/rules/base.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sqlglot.expressions import Expression
 
+    from jarify.comment_overrides import CommentOverrides
     from jarify.types import LintViolation
 
 
@@ -34,6 +35,9 @@ def _node_pos(node: Expression) -> tuple[int | None, int | None]:
 class FormatterRule(ABC):
     """A rule that can both check (lint) and transform (format) a SQL AST."""
 
+    def __init__(self, overrides: CommentOverrides | None = None) -> None:
+        self._overrides = overrides
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -46,6 +50,13 @@ class FormatterRule(ABC):
     def check(self, tree: Expression) -> list[LintViolation]:
         """Return violations found in the tree. Default: no violations."""
         return []
+
+    def enabled_for_line(self, line: int | None) -> bool:
+        return not (self._overrides and self._overrides.is_rule_disabled(self.name, line))
+
+    def enabled_for_node(self, node: Expression) -> bool:
+        line, _ = _node_pos(node)
+        return self.enabled_for_line(line)
 
 
 class LintOnlyRule(FormatterRule):

--- a/src/jarify/rules/consistent_empty_array.py
+++ b/src/jarify/rules/consistent_empty_array.py
@@ -12,7 +12,8 @@ from jarify.types import LintViolation
 class ConsistentEmptyArrayRule(FormatterRule):
     """Lint: flag '[]'::type[] (string-cast) in favour of native [] empty array literal."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -28,6 +29,8 @@ class ConsistentEmptyArrayRule(FormatterRule):
         violations: list[LintViolation] = []
 
         for cast in tree.find_all(exp.Cast):
+            if not self.enabled_for_node(cast):
+                continue
             if not (isinstance(cast.to, exp.DataType) and cast.to.this == DataType.Type.ARRAY):
                 continue
 

--- a/src/jarify/rules/cte_naming.py
+++ b/src/jarify/rules/cte_naming.py
@@ -11,7 +11,8 @@ from jarify.types import LintViolation
 class CteNamingRule(FormatterRule):
     """Lint: CTE names must begin with an underscore (e.g. _people)."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -25,7 +26,7 @@ class CteNamingRule(FormatterRule):
 
         renames: dict[str, str] = {}
         for cte in with_clause.expressions:
-            if cte.alias and not cte.alias.startswith("_"):
+            if cte.alias and not cte.alias.startswith("_") and self.enabled_for_node(cte):
                 renames[cte.alias] = f"_{cte.alias}"
 
         if not renames:
@@ -55,7 +56,7 @@ class CteNamingRule(FormatterRule):
         if not with_clause:
             return []
         for cte in with_clause.expressions:
-            if cte.alias and not cte.alias.startswith("_"):
+            if cte.alias and not cte.alias.startswith("_") and self.enabled_for_node(cte):
                 _line, _col = _node_pos(cte)
                 violations.append(
                     LintViolation(

--- a/src/jarify/rules/duckdb_prefer_qualify.py
+++ b/src/jarify/rules/duckdb_prefer_qualify.py
@@ -18,7 +18,8 @@ from jarify.types import LintViolation
 class DuckdbPreferQualifyRule(LintOnlyRule):
     """Lint: suggest QUALIFY instead of filtering on a window function in a subquery."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -32,6 +33,8 @@ class DuckdbPreferQualifyRule(LintOnlyRule):
 
         # Look for: SELECT ... FROM (subquery with window functions) WHERE <alias> = <literal>
         for select in tree.find_all(exp.Select):
+            if not self.enabled_for_node(select):
+                continue
             where = select.args.get("where")
             if not where:
                 continue

--- a/src/jarify/rules/duckdb_type_style.py
+++ b/src/jarify/rules/duckdb_type_style.py
@@ -29,7 +29,8 @@ class DuckdbTypeStyleRule(LintOnlyRule):
     be detected here.
     """
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -41,6 +42,8 @@ class DuckdbTypeStyleRule(LintOnlyRule):
             return []
         violations: list[LintViolation] = []
         for dtype in tree.find_all(exp.DataType):
+            if not self.enabled_for_node(dtype):
+                continue
             canonical = _NON_CANONICAL.get(dtype.this)
             if canonical:
                 raw = dtype.this.name

--- a/src/jarify/rules/keyword_case.py
+++ b/src/jarify/rules/keyword_case.py
@@ -20,7 +20,8 @@ class KeywordCaseRule(FormatterRule):
     AST transforms (e.g., normalizing user-defined function names).
     """
 
-    def __init__(self, uppercase: bool = True) -> None:
+    def __init__(self, uppercase: bool = True, overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.uppercase = uppercase
 
     @property

--- a/src/jarify/rules/no_implicit_cross_join.py
+++ b/src/jarify/rules/no_implicit_cross_join.py
@@ -21,7 +21,8 @@ def _is_comma_join(join: exp.Join) -> bool:
 class NoImplicitCrossJoinRule(FormatterRule):
     """Rewrite comma-joined tables to explicit CROSS JOIN; flag in lint output."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -30,7 +31,7 @@ class NoImplicitCrossJoinRule(FormatterRule):
 
     def apply(self, tree: exp.Expression) -> exp.Expression:
         for join in tree.find_all(exp.Join):
-            if _is_comma_join(join):
+            if _is_comma_join(join) and self.enabled_for_node(join):
                 join.set("kind", "CROSS")
         return tree
 
@@ -39,7 +40,7 @@ class NoImplicitCrossJoinRule(FormatterRule):
             return []
         violations: list[LintViolation] = []
         for join in tree.find_all(exp.Join):
-            if _is_comma_join(join):
+            if _is_comma_join(join) and self.enabled_for_node(join):
                 _line, _col = _node_pos(join)
                 violations.append(
                     LintViolation(

--- a/src/jarify/rules/no_select_star.py
+++ b/src/jarify/rules/no_select_star.py
@@ -11,7 +11,8 @@ from jarify.types import LintViolation
 class NoSelectStarRule(LintOnlyRule):
     """Flag SELECT * (or table.*) as a lint violation."""
 
-    def __init__(self, severity: str = "warn", prefer_from_first: bool = False) -> None:
+    def __init__(self, severity: str = "warn", prefer_from_first: bool = False, overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
         self.prefer_from_first = prefer_from_first
 
@@ -41,6 +42,8 @@ class NoSelectStarRule(LintOnlyRule):
                     and not select.args.get("distinct")
                     and not select.args.get("joins")
                 ):
+                    continue
+                if not self.enabled_for_node(star):
                     continue
                 _line, _col = _node_pos(star)
                 violations.append(

--- a/src/jarify/rules/no_select_star_in_cte.py
+++ b/src/jarify/rules/no_select_star_in_cte.py
@@ -11,7 +11,8 @@ from jarify.types import LintViolation
 class NoSelectStarInCteRule(LintOnlyRule):
     """Lint: flag SELECT * used inside a CTE body (stricter than no-select-star)."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -34,6 +35,8 @@ class NoSelectStarInCteRule(LintOnlyRule):
                 if isinstance(parent, exp.Select) or (
                     isinstance(parent, exp.Column) and isinstance(parent.parent, exp.Select)
                 ):
+                    if not self.enabled_for_node(star):
+                        continue
                     _line, _col = _node_pos(star)
                     violations.append(
                         LintViolation(

--- a/src/jarify/rules/no_unused_cte.py
+++ b/src/jarify/rules/no_unused_cte.py
@@ -11,7 +11,8 @@ from jarify.types import LintViolation
 class NoUnusedCteRule(LintOnlyRule):
     """Flag CTEs (WITH clause entries) that are never referenced in the query body."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -43,7 +44,7 @@ class NoUnusedCteRule(LintOnlyRule):
                 referenced.add(table.name.lower())
 
         for name in cte_names:
-            if name not in referenced:
+            if name not in referenced and self.enabled_for_node(cte_nodes[name]):
                 _line, _col = _node_pos(cte_nodes[name])
                 violations.append(
                     LintViolation(

--- a/src/jarify/rules/prefer_group_by_all.py
+++ b/src/jarify/rules/prefer_group_by_all.py
@@ -31,7 +31,8 @@ def _non_agg_sqls(select: exp.Select) -> set[str]:
 class PreferGroupByAllRule(FormatterRule):
     """Format and lint: rewrite explicit GROUP BY col list to GROUP BY ALL when equivalent."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -41,6 +42,8 @@ class PreferGroupByAllRule(FormatterRule):
     def apply(self, tree: exp.Expression) -> exp.Expression:
         """Rewrite GROUP BY <cols> → GROUP BY ALL when all non-agg SELECT cols are covered."""
         for select in tree.find_all(exp.Select):
+            if not self.enabled_for_node(select):
+                continue
             group = select.args.get("group")
             if not group or not group.expressions:
                 continue
@@ -64,6 +67,8 @@ class PreferGroupByAllRule(FormatterRule):
         violations: list[LintViolation] = []
 
         for select in tree.find_all(exp.Select):
+            if not self.enabled_for_node(select):
+                continue
             group = select.args.get("group")
             if not group or not group.expressions:
                 continue

--- a/src/jarify/rules/prefer_if_over_case.py
+++ b/src/jarify/rules/prefer_if_over_case.py
@@ -54,7 +54,8 @@ class PreferIfOverCaseRule(FormatterRule):
     rewrite criteria but has not yet been formatted.
     """
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -64,7 +65,7 @@ class PreferIfOverCaseRule(FormatterRule):
     def apply(self, tree: exp.Expression) -> exp.Expression:
         """Rewrite matching CASE nodes to exp.If in-place."""
         for case in tree.find_all(exp.Case):
-            if not _is_rewritable(case):
+            if not _is_rewritable(case) or not self.enabled_for_node(case):
                 continue
             if_branch = case.args["ifs"][0]
             condition = if_branch.args["this"]
@@ -88,7 +89,7 @@ class PreferIfOverCaseRule(FormatterRule):
             return []
         violations: list[LintViolation] = []
         for case in tree.find_all(exp.Case):
-            if not _is_rewritable(case):
+            if not _is_rewritable(case) or not self.enabled_for_node(case):
                 continue
             _line, _col = _node_pos(case)
             violations.append(

--- a/src/jarify/rules/prefer_neq_operator.py
+++ b/src/jarify/rules/prefer_neq_operator.py
@@ -24,7 +24,8 @@ class PreferNeqOperatorRule(FormatterRule):
     ``jarify fmt`` confirms the canonical form and silences the flag.
     """
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -40,6 +41,8 @@ class PreferNeqOperatorRule(FormatterRule):
             return []
         violations: list[LintViolation] = []
         for node in tree.find_all(exp.NEQ):
+            if not self.enabled_for_node(node):
+                continue
             _line, _col = _node_pos(node)
             violations.append(
                 LintViolation(

--- a/src/jarify/rules/prefer_using_over_on.py
+++ b/src/jarify/rules/prefer_using_over_on.py
@@ -11,7 +11,8 @@ from jarify.types import LintViolation
 class PreferUsingOverOnRule(LintOnlyRule):
     """Lint: flag ON a.col = b.col equi-joins where both sides share the same column name."""
 
-    def __init__(self, severity: str = "warn") -> None:
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
         self.severity = severity
 
     @property
@@ -24,6 +25,8 @@ class PreferUsingOverOnRule(LintOnlyRule):
         violations: list[LintViolation] = []
 
         for join in tree.find_all(exp.Join):
+            if not self.enabled_for_node(join):
+                continue
             if join.args.get("using"):
                 continue
             on = join.args.get("on")

--- a/src/jarify/rules/trailing_commas.py
+++ b/src/jarify/rules/trailing_commas.py
@@ -20,6 +20,9 @@ class TrailingCommasRule(FormatterRule):
     lint checks in future iterations.
     """
 
+    def __init__(self, overrides=None) -> None:
+        super().__init__(overrides=overrides)
+
     @property
     def name(self) -> str:
         return "trailing-commas"

--- a/tests/fixtures/comments/disable_case_rewrite.expected.sql
+++ b/tests/fixtures/comments/disable_case_rewrite.expected.sql
@@ -1,0 +1,9 @@
+-- jarify: disable prefer-if-over-case
+SELECT
+   CASE
+     WHEN a > 1
+     THEN 'big'
+     ELSE 'small'
+   END
+FROM t -- jarify: enable prefer-if-over-case
+;

--- a/tests/fixtures/comments/disable_case_rewrite.input.sql
+++ b/tests/fixtures/comments/disable_case_rewrite.input.sql
@@ -1,0 +1,3 @@
+-- jarify: disable prefer-if-over-case
+SELECT CASE WHEN a > 1 THEN 'big' ELSE 'small' END FROM t
+-- jarify: enable prefer-if-over-case

--- a/tests/test_comment_overrides.py
+++ b/tests/test_comment_overrides.py
@@ -41,6 +41,22 @@ class TestLintOverrides:
         sql = "-- jarify: disable-next-line no-select-star\nSELECT * FROM t"
         assert "no-select-star" not in _lint(sql, prefer_from_first=False)
 
+    def test_disable_next_line_suppresses_multiline_expression(self):
+        # CASE spans multiple lines after formatting; the directive is on the line
+        # before SELECT, so the violation must be suppressed across all body lines.
+        sql = (
+            "-- jarify: disable-next-line prefer-if-over-case\n"
+            "SELECT\n"
+            "   CASE\n"
+            "     WHEN a > 1\n"
+            "     THEN 'big'\n"
+            "     ELSE 'small'\n"
+            "   END\n"
+            "FROM t\n"
+            ";\n"
+        )
+        assert "prefer-if-over-case" not in _lint(sql)
+
     def test_disable_file_suppresses_entire_rule(self):
         sql = "-- jarify: disable-file no-select-star\nSELECT * FROM t\nSELECT * FROM u"
         assert "no-select-star" not in _lint(sql, prefer_from_first=False)

--- a/tests/test_comment_overrides.py
+++ b/tests/test_comment_overrides.py
@@ -1,0 +1,97 @@
+"""Tests for comment-based lint and format overrides."""
+
+from __future__ import annotations
+
+from jarify.comment_overrides import parse_comment_overrides
+from jarify.config import JarifyConfig
+from jarify.formatter import format_sql
+from jarify.linter import lint_sql
+
+
+def _lint(sql: str, **config_overrides) -> list[str]:
+    config = JarifyConfig(**config_overrides)
+    return [v.rule for v in lint_sql(sql, config)]
+
+
+class TestOverrideParsing:
+    def test_disable_region_tracks_until_enable(self):
+        overrides = parse_comment_overrides(
+            "-- jarify: disable no-select-star\nSELECT * FROM t\n-- jarify: enable no-select-star\nSELECT * FROM u\n"
+        )
+
+        assert overrides.is_rule_disabled("no-select-star", 2) is True
+        assert overrides.is_rule_disabled("no-select-star", 4) is False
+
+    def test_set_max_line_length_tracks_by_line(self):
+        overrides = parse_comment_overrides(
+            "-- jarify: set max_line_length = 200\nSELECT 1\n-- jarify: reset max_line_length\nSELECT 2\n"
+        )
+
+        config = JarifyConfig(max_line_length=40)
+        assert overrides.config_for_line(config, 2).max_line_length == 200
+        assert overrides.config_for_line(config, 4).max_line_length == 40
+
+
+class TestLintOverrides:
+    def test_disable_line_suppresses_inline_violation(self):
+        sql = "SELECT * FROM t -- jarify: disable-line no-select-star"
+        assert "no-select-star" not in _lint(sql, prefer_from_first=False)
+
+    def test_disable_next_line_suppresses_violation(self):
+        sql = "-- jarify: disable-next-line no-select-star\nSELECT * FROM t"
+        assert "no-select-star" not in _lint(sql, prefer_from_first=False)
+
+    def test_disable_file_suppresses_entire_rule(self):
+        sql = "-- jarify: disable-file no-select-star\nSELECT * FROM t\nSELECT * FROM u"
+        assert "no-select-star" not in _lint(sql, prefer_from_first=False)
+
+    def test_enable_restores_rule_after_region(self):
+        sql = "-- jarify: disable no-select-star\nSELECT * FROM t;\n-- jarify: enable no-select-star\nSELECT * FROM u\n"
+        assert _lint(sql, prefer_from_first=False) == ["no-select-star"]
+
+
+class TestFormatOverrides:
+    def test_disable_next_line_preserves_case_expression(self):
+        sql = (
+            "-- jarify: disable-next-line prefer-if-over-case\n"
+            "SELECT CASE WHEN a > 1 THEN 'big' ELSE 'small' END FROM t"
+        )
+
+        formatted, _ = format_sql(sql)
+
+        assert "CASE" in formatted
+        assert "if(" not in formatted
+
+    def test_disable_next_line_preserves_comma_join(self):
+        sql = "-- jarify: disable-next-line no-implicit-cross-join\nSELECT a FROM t1, t2"
+
+        formatted, _ = format_sql(sql)
+
+        assert "CROSS JOIN" not in formatted
+        assert "FROM t1, t2" in formatted
+
+    def test_disable_next_line_preserves_cte_name(self):
+        sql = "-- jarify: disable-next-line cte-naming\nWITH people AS (SELECT 1 AS id) SELECT id FROM people"
+
+        formatted, _ = format_sql(sql)
+
+        assert "WITH people AS" in formatted
+        assert "_people" not in formatted
+
+    def test_set_max_line_length_applies_to_following_statement(self):
+        sql = (
+            "-- jarify: set max_line_length = 200\n"
+            "SELECT if("
+            "really_long_condition_name > 10, "
+            "really_long_true_value_name, "
+            "really_long_false_value_name"
+            ") FROM t"
+        )
+
+        formatted, _ = format_sql(sql, JarifyConfig(max_line_length=40))
+
+        assert (
+            "if(really_long_condition_name > 10, really_long_true_value_name, really_long_false_value_name)"
+            in formatted
+        )
+        assert "if(\n" not in formatted


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- add `jarify:` comment directives for rule-level overrides in `fmt` and `lint`
- support `disable-line`, `disable-next-line`, `disable`, `enable`, and `disable-file` scopes
- support `set max_line_length = ...` / `reset max_line_length` for following statements
- document the directives in `docs/sql-style-guide.md` and cover them with fixtures and tests

## Testing
- `mise run check`

Resolves #265
