### PR TITLE
feat: handle SQLMesh SQL files

### DIFF
--- a/src/jarify/formatter.py
+++ b/src/jarify/formatter.py
@@ -26,6 +26,12 @@ from jarify.parser import (
 )
 from jarify.rules import get_default_rules
 from jarify.rules.base import FormatterRule, _node_pos
+from jarify.sqlmesh import (
+    looks_like_sqlmesh,
+    mask_sqlmesh_runtime_tokens,
+    split_sqlmesh_segments,
+    unmask_sqlmesh_runtime_tokens,
+)
 
 
 class FormatWarning:
@@ -49,6 +55,24 @@ def format_sql(
     original SQL is returned unchanged with a warning.
     """
     config = config or JarifyConfig()
+    if not looks_like_sqlmesh(sql):
+        return _format_sql_core(sql, config)
+
+    warnings: list[FormatWarning] = []
+    formatted_segments: list[str] = []
+    for segment in split_sqlmesh_segments(sql):
+        if segment.kind == "opaque" or not segment.text.strip():
+            formatted_segments.append(segment.text)
+            continue
+        formatted, segment_warnings = _format_sql_core(segment.text, config)
+        formatted_segments.append(formatted)
+        warnings.extend(segment_warnings)
+
+    return "".join(formatted_segments), warnings
+
+
+def _format_sql_core(sql: str, config: JarifyConfig) -> tuple[str, list[FormatWarning]]:
+    """Format a parseable SQL segment, preserving existing non-SQLMesh behavior."""
     warnings: list[FormatWarning] = []
     overrides = parse_comment_overrides(sql)
 
@@ -62,6 +86,7 @@ def format_sql(
     # Inline placeholders are masked with dummy identifiers that survive the AST.
     stripped_sql, line_insertions = _extract_line_rust_fmt_placeholders(processed_sql)
     masked_sql, inline_mask = _mask_rust_fmt_placeholders(stripped_sql)
+    masked_sql, sqlmesh_mask = mask_sqlmesh_runtime_tokens(masked_sql)
     masked_sql = _mask_ifnull(masked_sql)
     masked_sql = _mask_numeric(masked_sql)
 
@@ -70,9 +95,10 @@ def format_sql(
     except ParseError as exc:
         result = _try_pivot_order_by_workaround(masked_sql, config)
         if result is not None:
-            result = _unmask_rust_fmt_placeholders(result, inline_mask)
-            result = _unmask_ifnull(result)
             result = _unmask_numeric(result)
+            result = _unmask_ifnull(result)
+            result = unmask_sqlmesh_runtime_tokens(result, sqlmesh_mask)
+            result = _unmask_rust_fmt_placeholders(result, inline_mask)
             result = _reinsert_line_rust_fmt_placeholders(result, line_insertions)
             return _restore_ctas_body_placeholders(result, ctas_body_map), warnings
         warnings.append(FormatWarning(f"could not parse SQL (formatting skipped): {exc}"))
@@ -102,9 +128,10 @@ def format_sql(
     # that no-anchor placeholder re-insertion does not concatenate directly onto
     # the last SQL token without a line break.
     formatted = "\n;\n\n".join(formatted_parts) + ("\n" if formatted_parts else "")
-    formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
-    formatted = _unmask_ifnull(formatted)
     formatted = _unmask_numeric(formatted)
+    formatted = _unmask_ifnull(formatted)
+    formatted = unmask_sqlmesh_runtime_tokens(formatted, sqlmesh_mask)
+    formatted = _unmask_rust_fmt_placeholders(formatted, inline_mask)
     result = _reinsert_line_rust_fmt_placeholders(formatted, line_insertions)
     if formatted_parts:
         result = result.rstrip() + "\n;\n"

--- a/src/jarify/linter.py
+++ b/src/jarify/linter.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from jarify.comment_overrides import parse_comment_overrides
 from jarify.config import JarifyConfig
-from jarify.parser import _mask_ifnull, _mask_rust_fmt_placeholders, parse_sql_lenient
+from jarify.parser import _mask_ifnull, _mask_numeric, _mask_rust_fmt_placeholders, parse_sql_lenient
 from jarify.rules import get_default_rules
+from jarify.sqlmesh import looks_like_sqlmesh, mask_sqlmesh_runtime_tokens, split_sqlmesh_segments
 from jarify.types import LintViolation
 
 __all__ = ["LintViolation", "lint_sql"]
@@ -14,9 +15,23 @@ __all__ = ["LintViolation", "lint_sql"]
 def lint_sql(sql: str, config: JarifyConfig | None = None) -> list[LintViolation]:
     """Lint a SQL string and return a list of violations."""
     config = config or JarifyConfig()
+    if not looks_like_sqlmesh(sql):
+        return _lint_sql_core(sql, config)
+
+    violations: list[LintViolation] = []
+    for segment in split_sqlmesh_segments(sql):
+        if segment.kind == "sql" and segment.text.strip():
+            violations.extend(_lint_sql_core(segment.text, config))
+    return violations
+
+
+def _lint_sql_core(sql: str, config: JarifyConfig) -> list[LintViolation]:
+    """Lint one SQL segment."""
     overrides = parse_comment_overrides(sql)
     masked_sql, _ = _mask_rust_fmt_placeholders(sql)
+    masked_sql, _ = mask_sqlmesh_runtime_tokens(masked_sql)
     masked_sql = _mask_ifnull(masked_sql)
+    masked_sql = _mask_numeric(masked_sql)
     trees, parse_errors = parse_sql_lenient(masked_sql, dialect=config.dialect)
     violations: list[LintViolation] = []
 

--- a/src/jarify/sqlmesh.py
+++ b/src/jarify/sqlmesh.py
@@ -1,0 +1,360 @@
+"""SQLMesh-aware segmentation and runtime token masking helpers.
+
+These helpers intentionally do not parse SQLMesh.  They preserve SQLMesh-only
+wrappers and opaque Jinja blocks verbatim, then make inline runtime tokens look
+like ordinary SQL identifiers so sqlglot can format/lint the surrounding SQL.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class SqlMeshSegment:
+    """A byte-preserved SQLMesh document segment."""
+
+    kind: Literal["sql", "opaque"]
+    text: str
+
+
+_SQLMESH_AT_IDENTIFIER_RE = re.compile(r"@[A-Za-z_]\w*\b")
+_HEADER_RE = re.compile(r"\b(MODEL|AUDIT)\s*\(", re.IGNORECASE)
+_LEADING_HEADER_RE = re.compile(r"(?:MODEL|AUDIT)\s*\(", re.IGNORECASE)
+_SQLMESH_MARKER_RE = re.compile(
+    r"\b(?:ON_VIRTUAL_UPDATE_BEGIN|ON_VIRTUAL_UPDATE_END|JINJA_STATEMENT_BEGIN|JINJA_END)\b"
+)
+_JINJA_EXPR_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
+_WHOLE_LINE_JINJA_EXPR_RE = re.compile(r"^\s*\{\{.*\}\}\s*;?\s*$", re.DOTALL)
+_WHOLE_LINE_JINJA_STMT_RE = re.compile(r"^\s*\{%-?\s*(\w+)", re.IGNORECASE)
+_JINJA_BLOCK_START = frozenset({"if", "for", "macro", "filter", "set", "block", "call", "with"})
+_JINJA_BLOCK_END = frozenset({"endif", "endfor", "endmacro", "endfilter", "endset", "endblock", "endcall", "endwith"})
+
+
+def looks_like_sqlmesh(sql: str) -> bool:
+    """Return True when *sql* contains SQLMesh wrapper/template markers."""
+    leading = _skip_leading_space_and_comments(sql, 0)
+    if _LEADING_HEADER_RE.match(sql, leading):
+        return True
+    if _SQLMESH_MARKER_RE.search(sql):
+        return True
+    if "{{" in sql or "{%" in sql:
+        return True
+    return _contains_sqlmesh_at_identifier(sql)
+
+
+def split_sqlmesh_segments(sql: str) -> list[SqlMeshSegment]:
+    """Split a SQLMesh document into formatable SQL and opaque segments."""
+    if not sql:
+        return [SqlMeshSegment("sql", sql)]
+
+    segments: list[SqlMeshSegment] = []
+    pos = 0
+
+    while True:
+        header_start = _skip_leading_space_and_comments(sql, pos)
+        match = _LEADING_HEADER_RE.match(sql, header_start)
+        if not match:
+            break
+        header_end = _find_balanced_call_end(sql, match.start())
+        if header_end is None:
+            break
+        opaque_end = _consume_optional_semicolon_and_blank_lines(sql, header_end)
+        _append_segment(segments, "opaque", sql[pos:opaque_end])
+        pos = opaque_end
+
+    _append_line_segments(segments, sql[pos:])
+    return segments or [SqlMeshSegment("sql", sql)]
+
+
+def mask_sqlmesh_runtime_tokens(sql: str) -> tuple[str, dict[str, str]]:
+    """Mask inline SQLMesh/Jinja runtime tokens with valid SQL identifiers."""
+    source_sql = sql
+    mapping: dict[str, str] = {}
+    used_markers: set[str] = set()
+    seq = 0
+
+    def next_marker(original: str) -> str:
+        nonlocal seq
+        while True:
+            marker = f"__jsm{seq}__"
+            seq += 1
+            if len(marker) < len(original):
+                marker += "_" * (len(original) - len(marker))
+            if marker in source_sql or marker in used_markers:
+                continue
+            used_markers.add(marker)
+            mapping[marker] = original
+            return marker
+
+    sql = _JINJA_EXPR_RE.sub(lambda m: next_marker(m.group(0)), sql)
+    if "@" not in sql:
+        return sql, mapping
+
+    return _replace_sqlmesh_at_identifiers(sql, next_marker), mapping
+
+
+def unmask_sqlmesh_runtime_tokens(sql: str, mapping: dict[str, str]) -> str:
+    """Restore SQLMesh/Jinja runtime tokens from *mapping*."""
+    for marker, original in mapping.items():
+        sql = sql.replace(marker, original)
+    return sql
+
+
+def _contains_sqlmesh_at_identifier(sql: str) -> bool:
+    return _replace_sqlmesh_at_identifiers(sql, lambda _original: "") != sql
+
+
+def _replace_sqlmesh_at_identifiers(sql: str, replacement_for: Callable[[str], str]) -> str:
+    parts: list[str] = []
+    i = 0
+    state = "code"
+    changed = False
+
+    while i < len(sql):
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < len(sql) else ""
+
+        if state == "code":
+            if ch == "'":
+                state = "single"
+                parts.append(ch)
+                i += 1
+                continue
+            if ch == '"':
+                state = "double"
+                parts.append(ch)
+                i += 1
+                continue
+            if ch == "-" and nxt == "-":
+                state = "line_comment"
+                parts.append(ch + nxt)
+                i += 2
+                continue
+            if ch == "/" and nxt == "*":
+                state = "block_comment"
+                parts.append(ch + nxt)
+                i += 2
+                continue
+            match = _SQLMESH_AT_IDENTIFIER_RE.match(sql, i)
+            if match:
+                parts.append(replacement_for(match.group(0)))
+                i = match.end()
+                changed = True
+                continue
+            parts.append(ch)
+            i += 1
+            continue
+
+        parts.append(ch)
+        i += 1
+        if state == "single":
+            if ch == "'" and nxt == "'":
+                parts.append(nxt)
+                i += 1
+            elif ch == "'":
+                state = "code"
+        elif state == "double":
+            if ch == '"' and nxt == '"':
+                parts.append(nxt)
+                i += 1
+            elif ch == '"':
+                state = "code"
+        elif state == "line_comment" and ch in "\r\n":
+            state = "code"
+        elif state == "block_comment" and ch == "*" and nxt == "/":
+            parts.append(nxt)
+            i += 1
+            state = "code"
+
+    return "".join(parts) if changed else sql
+
+
+def _append_segment(segments: list[SqlMeshSegment], kind: Literal["sql", "opaque"], text: str) -> None:
+    if not text:
+        return
+    if segments and segments[-1].kind == kind:
+        segments[-1] = SqlMeshSegment(kind, segments[-1].text + text)
+    else:
+        segments.append(SqlMeshSegment(kind, text))
+
+
+def _append_line_segments(segments: list[SqlMeshSegment], sql: str) -> None:
+    lines = sql.splitlines(keepends=True)
+    sql_buf: list[str] = []
+    i = 0
+
+    def flush_sql() -> None:
+        nonlocal sql_buf
+        if not sql_buf:
+            return
+        first_sql = next((idx for idx, sql_line in enumerate(sql_buf) if sql_line.strip()), None)
+        if first_sql is None:
+            _append_segment(segments, "opaque", "".join(sql_buf))
+            sql_buf = []
+            return
+        last_sql = max(idx for idx, sql_line in enumerate(sql_buf) if sql_line.strip())
+        _append_segment(segments, "opaque", "".join(sql_buf[:first_sql]))
+        _append_segment(segments, "sql", "".join(sql_buf[first_sql : last_sql + 1]))
+        _append_segment(segments, "opaque", "".join(sql_buf[last_sql + 1 :]))
+        sql_buf = []
+
+    while i < len(lines):
+        line = lines[i]
+        if "JINJA_STATEMENT_BEGIN" in line:
+            flush_sql()
+            block = [line]
+            i += 1
+            while i < len(lines):
+                block.append(lines[i])
+                end = "JINJA_END" in lines[i]
+                i += 1
+                if end:
+                    break
+            _append_segment(segments, "opaque", "".join(block))
+            continue
+
+        if "ON_VIRTUAL_UPDATE_BEGIN" in line or "ON_VIRTUAL_UPDATE_END" in line:
+            flush_sql()
+            _append_segment(segments, "opaque", line)
+            i += 1
+            continue
+
+        if _WHOLE_LINE_JINJA_EXPR_RE.match(line):
+            flush_sql()
+            _append_segment(segments, "opaque", line)
+            i += 1
+            continue
+
+        jinja_match = _WHOLE_LINE_JINJA_STMT_RE.match(line)
+        if jinja_match:
+            tag = jinja_match.group(1).lower()
+            flush_sql()
+            block, i = _collect_jinja_statement_block(lines, i, tag)
+            _append_segment(segments, "opaque", "".join(block))
+            continue
+
+        sql_buf.append(line)
+        i += 1
+
+    flush_sql()
+
+
+def _collect_jinja_statement_block(lines: list[str], start: int, first_tag: str) -> tuple[list[str], int]:
+    block: list[str] = []
+    depth = 0
+    i = start
+    is_block = first_tag in _JINJA_BLOCK_START
+
+    while i < len(lines):
+        line = lines[i]
+        block.append(line)
+        match = _WHOLE_LINE_JINJA_STMT_RE.match(line)
+        if match:
+            tag = match.group(1).lower()
+            if tag in _JINJA_BLOCK_START:
+                depth += 1
+            elif tag in _JINJA_BLOCK_END:
+                depth = max(0, depth - 1)
+        i += 1
+        if not is_block or depth == 0:
+            break
+
+    return block, i
+
+
+def _skip_leading_space_and_comments(sql: str, pos: int) -> int:
+    i = pos
+    while i < len(sql):
+        if sql[i].isspace():
+            i += 1
+            continue
+        if sql.startswith("--", i):
+            newline = sql.find("\n", i + 2)
+            if newline == -1:
+                return len(sql)
+            i = newline + 1
+            continue
+        if sql.startswith("/*", i):
+            end = sql.find("*/", i + 2)
+            if end == -1:
+                return len(sql)
+            i = end + 2
+            continue
+        break
+    return i
+
+
+def _consume_optional_semicolon_and_blank_lines(sql: str, pos: int) -> int:
+    i = pos
+    while i < len(sql) and sql[i] in " \t":
+        i += 1
+    if i < len(sql) and sql[i] == ";":
+        i += 1
+    if i < len(sql) and sql[i] == "\r":
+        i += 1
+    if i < len(sql) and sql[i] == "\n":
+        i += 1
+    while True:
+        line_end = sql.find("\n", i)
+        if line_end == -1:
+            line = sql[i:]
+            if line.strip():
+                return i
+            return len(sql)
+        line = sql[i : line_end + 1]
+        if line.strip():
+            return i
+        i = line_end + 1
+
+
+def _find_balanced_call_end(sql: str, call_start: int) -> int | None:
+    match = _HEADER_RE.match(sql, call_start)
+    if not match:
+        return None
+
+    depth = 0
+    i = match.end() - 1
+    state = "code"
+    while i < len(sql):
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < len(sql) else ""
+
+        if state == "code":
+            if ch == "'":
+                state = "single"
+            elif ch == '"':
+                state = "double"
+            elif ch == "-" and nxt == "-":
+                state = "line_comment"
+                i += 1
+            elif ch == "/" and nxt == "*":
+                state = "block_comment"
+                i += 1
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+        elif state == "single":
+            if ch == "'" and nxt == "'":
+                i += 1
+            elif ch == "'":
+                state = "code"
+        elif state == "double":
+            if ch == '"' and nxt == '"':
+                i += 1
+            elif ch == '"':
+                state = "code"
+        elif state == "line_comment" and ch in "\r\n":
+            state = "code"
+        elif state == "block_comment" and ch == "*" and nxt == "/":
+            state = "code"
+            i += 1
+        i += 1
+
+    return None

--- a/tests/fixtures/sqlmesh/audit.expected.sql
+++ b/tests/fixtures/sqlmesh/audit.expected.sql
@@ -1,0 +1,8 @@
+AUDIT (
+  name assert_positive_amount,
+  dialect duckdb
+);
+
+FROM orders
+WHERE amount < 0
+;

--- a/tests/fixtures/sqlmesh/audit.input.sql
+++ b/tests/fixtures/sqlmesh/audit.input.sql
@@ -1,0 +1,6 @@
+AUDIT (
+  name assert_positive_amount,
+  dialect duckdb
+);
+
+select * from orders where amount < 0

--- a/tests/fixtures/sqlmesh/basic_model.expected.sql
+++ b/tests/fixtures/sqlmesh/basic_model.expected.sql
@@ -1,0 +1,12 @@
+MODEL (
+  name foo.orders,
+  kind FULL,
+  dialect duckdb
+);
+
+SELECT
+   order_id
+  ,amount
+FROM {{ ref('raw_orders') }}
+WHERE ds BETWEEN @start_dt AND @end_dt
+;

--- a/tests/fixtures/sqlmesh/basic_model.input.sql
+++ b/tests/fixtures/sqlmesh/basic_model.input.sql
@@ -1,0 +1,7 @@
+MODEL (
+  name foo.orders,
+  kind FULL,
+  dialect duckdb
+);
+
+select order_id,amount from {{ ref('raw_orders') }} where ds between @start_dt and @end_dt

--- a/tests/fixtures/sqlmesh/jinja_opaque.expected.sql
+++ b/tests/fixtures/sqlmesh/jinja_opaque.expected.sql
@@ -1,0 +1,15 @@
+MODEL (name foo.jinja_model);
+
+SELECT
+   1 AS before_block
+;
+{% if is_incremental() %}
+select bad,unformatted from raw_table
+{% endif %}
+JINJA_STATEMENT_BEGIN;
+select {{ macro_value() }}
+JINJA_END;
+SELECT
+   {{ dim_col }} AS dim
+FROM {{ ref('dim_table') }}
+;

--- a/tests/fixtures/sqlmesh/jinja_opaque.input.sql
+++ b/tests/fixtures/sqlmesh/jinja_opaque.input.sql
@@ -1,0 +1,10 @@
+MODEL (name foo.jinja_model);
+
+select 1 as before_block
+{% if is_incremental() %}
+select bad,unformatted from raw_table
+{% endif %}
+JINJA_STATEMENT_BEGIN;
+select {{ macro_value() }}
+JINJA_END;
+select {{ dim_col }} as dim from {{ ref('dim_table') }}

--- a/tests/fixtures/sqlmesh/pre_post_statements.expected.sql
+++ b/tests/fixtures/sqlmesh/pre_post_statements.expected.sql
@@ -1,0 +1,24 @@
+MODEL (
+  name foo.pre_post_orders,
+  kind FULL,
+  dialect duckdb
+);
+
+CREATE OR REPLACE TEMPORARY TABLE _jarify_stage_orders AS
+SELECT
+   order_id
+  ,amount
+  ,ds
+FROM @input_model
+WHERE ds = @run_dt
+;
+
+SELECT
+   order_id
+  ,amount
+FROM _jarify_stage_orders
+WHERE amount > 0
+;
+
+DROP TABLE IF EXISTS _jarify_stage_orders
+;

--- a/tests/fixtures/sqlmesh/pre_post_statements.input.sql
+++ b/tests/fixtures/sqlmesh/pre_post_statements.input.sql
@@ -1,0 +1,12 @@
+MODEL (
+  name foo.pre_post_orders,
+  kind FULL,
+  dialect duckdb
+);
+
+create or replace temp table _jarify_stage_orders as
+select order_id,amount,ds from @input_model where ds = @run_dt;
+
+select order_id,amount from _jarify_stage_orders where amount > 0;
+
+drop table if exists _jarify_stage_orders;

--- a/tests/fixtures/sqlmesh/virtual_update.expected.sql
+++ b/tests/fixtures/sqlmesh/virtual_update.expected.sql
@@ -1,0 +1,16 @@
+MODEL (name foo.virtual_model);
+
+ON_VIRTUAL_UPDATE_BEGIN;
+SELECT
+   id
+  ,status
+FROM @this_model
+WHERE updated_at >= @start_dt
+;
+ON_VIRTUAL_UPDATE_END;
+
+SELECT
+   id
+  ,status
+FROM raw_status
+;

--- a/tests/fixtures/sqlmesh/virtual_update.input.sql
+++ b/tests/fixtures/sqlmesh/virtual_update.input.sql
@@ -1,0 +1,7 @@
+MODEL (name foo.virtual_model);
+
+ON_VIRTUAL_UPDATE_BEGIN;
+select id,status from @this_model where updated_at >= @start_dt
+ON_VIRTUAL_UPDATE_END;
+
+select id,status from raw_status

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -30,6 +30,10 @@ def _collect_fixture_pairs() -> list[tuple[str, Path, Path]]:
     return pairs
 
 
+def _is_sqlmesh_fixture(path: Path) -> bool:
+    return path.relative_to(FIXTURES_DIR).parts[0] == "sqlmesh"
+
+
 @pytest.mark.parametrize(
     "test_id,input_path,expected_path",
     [pytest.param(tid, inp, exp, id=tid) for tid, inp, exp in _collect_fixture_pairs()],
@@ -43,7 +47,9 @@ def test_format_fixture(
     """Format input SQL and compare to the expected snapshot."""
     config = JarifyConfig()
     sql = input_path.read_text()
-    result, _ = format_sql(sql, config)
+    result, warnings = format_sql(sql, config)
+    if _is_sqlmesh_fixture(input_path):
+        assert not warnings, f"SQLMesh fixture emitted format warnings: {[str(w) for w in warnings]}"
 
     if update_snapshots:
         expected_path.write_text(result)
@@ -67,7 +73,9 @@ def test_format_idempotent(request: pytest.FixtureRequest) -> None:
         if not expected_path.exists():
             continue
         already_formatted = expected_path.read_text().rstrip("\n") + "\n"
-        result, _ = format_sql(already_formatted, config)
+        result, warnings = format_sql(already_formatted, config)
+        if _is_sqlmesh_fixture(expected_path):
+            assert not warnings, f"SQLMesh fixture emitted format warnings: {[str(w) for w in warnings]}"
         assert result == already_formatted, (
             f"Idempotency failure for {expected_path.name}:\n"
             f"--- first pass output ---\n{already_formatted}"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -413,3 +413,68 @@ class TestTrailingRustFmtPlaceholder:
         out, _ = format_sql(sql)
         out2, _ = format_sql(out)
         assert out == out2, f"Formatting is not idempotent:\nFirst pass:\n{out}\nSecond pass:\n{out2}"
+
+
+class TestSQLMeshFormatting:
+    def test_model_header_preserved_and_body_formatted(self):
+        header = "MODEL (\n  name foo.bar,\n  kind FULL\n);\n\n"
+        sql = header + "select a,b from t where x=1\n"
+        out, warnings = format_sql(sql)
+        assert not warnings
+        assert out.startswith(header)
+        assert "SELECT\n   a\n  ,b\nFROM t\nWHERE x = 1\n;\n" in out
+
+    def test_audit_header_preserved_and_body_formatted(self):
+        header = "AUDIT (\n  name assert_positive,\n);\n"
+        sql = header + "select * from tbl where amount<0\n"
+        out, warnings = format_sql(sql)
+        assert not warnings
+        assert out.startswith(header)
+        assert "FROM tbl\nWHERE amount < 0\n;\n" in out
+
+    def test_sqlmesh_macro_vars_survive_formatting(self):
+        sql = "MODEL (name foo.bar);\nselect a from t where ds between @start_dt and @end_dt\n"
+        out, warnings = format_sql(sql)
+        assert not warnings
+        assert "WHERE ds BETWEEN @start_dt AND @end_dt" in out
+
+    def test_arbitrary_sqlmesh_at_identifiers_survive_formatting(self):
+        sql = (
+            "select @EACH(account_id) as account_id from @input_model "
+            "where ds = @run_dt and note <> '@run_dt' -- @input_model\n"
+        )
+        out, warnings = format_sql(sql)
+        assert not warnings
+        assert "@EACH(account_id) AS account_id" in out
+        assert "FROM @input_model" in out
+        assert "WHERE ds = @run_dt" in out
+        assert "note != '@run_dt' -- @input_model" in out
+
+    def test_inline_jinja_expressions_survive_formatting(self):
+        sql = "select {{ dim_col }} as dim from {{ ref('orders') }} where ds = {{ var('ds') }}\n"
+        out, warnings = format_sql(sql)
+        assert not warnings
+        assert "{{ dim_col }} AS dim" in out
+        assert "FROM {{ ref('orders') }}" in out
+        assert "WHERE ds = {{ var('ds') }}" in out
+
+    def test_whole_jinja_control_block_stays_opaque(self):
+        block = "{% if is_incremental() %}\nselect bad,unformatted from raw\n{% endif %}\n"
+        sql = "select 1 as a\n" + block + "select 2 as b\n"
+        out, warnings = format_sql(sql)
+        assert not warnings
+        assert block in out
+        assert "SELECT\n   1 AS a\n;\n" in out
+        assert "SELECT\n   2 AS b\n;\n" in out
+
+    def test_sqlmesh_formatting_is_idempotent(self):
+        sql = (
+            "MODEL (\n  name foo.bar,\n  kind FULL\n);\n\n"
+            "select {{ dim_col }} as dim from {{ ref('orders') }} "
+            "where ds between @start_dt and @end_dt\n"
+        )
+        out, warnings = format_sql(sql)
+        out2, warnings2 = format_sql(out)
+        assert not warnings
+        assert not warnings2
+        assert out == out2

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -417,3 +417,31 @@ class TestPreferIfnullOverCoalesce:
         sql = "SELECT coalesce(a, b) FROM t"
         rules = _lint(sql, prefer_ifnull_over_coalesce="off")
         assert "prefer-ifnull-over-coalesce" not in rules
+
+
+class TestSQLMeshSyntax:
+    def test_model_header_no_parse_error_but_rules_still_fire(self):
+        sql = "MODEL (name foo.bar);\nSELECT * FROM t\n"
+        rules = _lint(sql, prefer_from_first=False)
+        assert "parse-error" not in rules
+        assert "no-select-star" in rules
+
+    def test_jinja_statement_block_no_parse_error(self):
+        sql = "JINJA_STATEMENT_BEGIN;\nselect {{ x }}\nJINJA_END;\nSELECT 1\n"
+        rules = _lint(sql)
+        assert "parse-error" not in rules
+
+    def test_macro_vars_no_parse_error(self):
+        sql = "MODEL (name foo.bar);\nSELECT a FROM t WHERE ds BETWEEN @start_dt AND @end_dt\n"
+        rules = _lint(sql)
+        assert "parse-error" not in rules
+
+    def test_arbitrary_at_identifiers_no_parse_error(self):
+        sql = "SELECT a FROM @input_model WHERE ds = @run_dt AND account_id IN (@EACH(account_id))\n"
+        rules = _lint(sql)
+        assert "parse-error" not in rules
+
+    def test_invalid_real_sql_segment_still_reports_parse_error(self):
+        sql = "MODEL (name foo.bar);\nTHIS IS NOT VALID SQL @@@!!!\n"
+        rules = _lint(sql)
+        assert "parse-error" in rules

--- a/tests/test_sqlmesh.py
+++ b/tests/test_sqlmesh.py
@@ -1,0 +1,122 @@
+"""Tests for SQLMesh segmentation and runtime token masking."""
+
+from jarify.sqlmesh import (
+    looks_like_sqlmesh,
+    mask_sqlmesh_runtime_tokens,
+    split_sqlmesh_segments,
+    unmask_sqlmesh_runtime_tokens,
+)
+
+
+def test_looks_like_sqlmesh_detects_known_markers():
+    assert looks_like_sqlmesh("MODEL (name foo.bar);\nSELECT 1")
+    assert looks_like_sqlmesh("AUDIT (name assert_positive);\nSELECT 1")
+    assert looks_like_sqlmesh("ON_VIRTUAL_UPDATE_BEGIN;\nSELECT 1")
+    assert looks_like_sqlmesh("JINJA_STATEMENT_BEGIN;\nSELECT 1\nJINJA_END;")
+    assert looks_like_sqlmesh("SELECT * FROM @this_model WHERE ds >= @start_dt")
+    assert looks_like_sqlmesh("SELECT * FROM @input_model WHERE ds = @run_dt")
+
+
+def test_looks_like_sqlmesh_ignores_at_identifiers_in_strings_and_comments():
+    sql = "SELECT '@run_dt' AS literal -- @input_model\n/* @block */"
+    assert not looks_like_sqlmesh(sql)
+
+
+def test_normal_sql_is_single_sql_segment_and_mask_noop():
+    sql = "SELECT a, b FROM t WHERE ds > DATE '2025-01-01'"
+    assert not looks_like_sqlmesh(sql)
+    assert split_sqlmesh_segments(sql)[0].kind == "sql"
+    assert split_sqlmesh_segments(sql)[0].text == sql
+    masked, mapping = mask_sqlmesh_runtime_tokens(sql)
+    assert masked == sql
+    assert mapping == {}
+
+
+def test_split_preserves_leading_model_header():
+    sql = "MODEL (\n  name foo.bar,\n  kind FULL\n);\n\nselect a,b from t\n"
+    segments = split_sqlmesh_segments(sql)
+    assert [(s.kind, s.text) for s in segments] == [
+        ("opaque", "MODEL (\n  name foo.bar,\n  kind FULL\n);\n\n"),
+        ("sql", "select a,b from t\n"),
+    ]
+
+
+def test_split_header_ignores_parentheses_in_strings_and_comments():
+    sql = (
+        "MODEL (\n"
+        "  name foo.bar,\n"
+        "  description 'literal ) paren',\n"
+        "  cron '@daily', -- comment )\n"
+        "  owner (team)\n"
+        ");\n"
+        "SELECT 1\n"
+    )
+    segments = split_sqlmesh_segments(sql)
+    assert segments[0].kind == "opaque"
+    assert segments[0].text.startswith("MODEL (")
+    assert segments[0].text.endswith(");\n")
+    assert segments[1].text == "SELECT 1\n"
+
+
+def test_split_virtual_update_markers_only():
+    sql = "ON_VIRTUAL_UPDATE_BEGIN;\nselect a,b from t\nON_VIRTUAL_UPDATE_END;\n"
+    segments = split_sqlmesh_segments(sql)
+    assert [(s.kind, s.text) for s in segments] == [
+        ("opaque", "ON_VIRTUAL_UPDATE_BEGIN;\n"),
+        ("sql", "select a,b from t\n"),
+        ("opaque", "ON_VIRTUAL_UPDATE_END;\n"),
+    ]
+
+
+def test_split_jinja_statement_marker_block_is_opaque():
+    sql = "JINJA_STATEMENT_BEGIN;\nselect {{ x }}\nJINJA_END;\nselect 1\n"
+    segments = split_sqlmesh_segments(sql)
+    assert [(s.kind, s.text) for s in segments] == [
+        ("opaque", "JINJA_STATEMENT_BEGIN;\nselect {{ x }}\nJINJA_END;\n"),
+        ("sql", "select 1\n"),
+    ]
+
+
+def test_split_whole_line_jinja_control_block_is_opaque():
+    sql = "select 1\n{% if is_incremental() %}\nselect * from raw\n{% endif %}\nselect 2\n"
+    segments = split_sqlmesh_segments(sql)
+    assert [(s.kind, s.text) for s in segments] == [
+        ("sql", "select 1\n"),
+        ("opaque", "{% if is_incremental() %}\nselect * from raw\n{% endif %}\n"),
+        ("sql", "select 2\n"),
+    ]
+
+
+def test_mask_sqlmesh_runtime_tokens_round_trips_exactly():
+    sql = "SELECT {{ ref('x') }} AS model_name FROM @this_model WHERE ds BETWEEN @start_dt AND @end_dt"
+    masked, mapping = mask_sqlmesh_runtime_tokens(sql)
+    assert "{{ ref('x') }}" not in masked
+    assert "@this_model" not in masked
+    assert "@start_dt" not in masked
+    assert "@end_dt" not in masked
+    assert unmask_sqlmesh_runtime_tokens(masked, mapping) == sql
+
+
+def test_mask_sqlmesh_runtime_tokens_masks_arbitrary_at_identifiers_only_in_code():
+    sql = (
+        "SELECT @EACH(account_id) AS account_id FROM @input_model "
+        "WHERE ds = @run_dt AND note = '@run_dt' -- @input_model\n"
+        "/* @EACH */"
+    )
+    masked, mapping = mask_sqlmesh_runtime_tokens(sql)
+    assert "@EACH(account_id)" not in masked
+    assert "FROM @input_model" not in masked
+    assert "ds = @run_dt" not in masked
+    assert "note = '@run_dt'" in masked
+    assert "-- @input_model" in masked
+    assert "/* @EACH */" in masked
+    assert unmask_sqlmesh_runtime_tokens(masked, mapping) == sql
+
+
+def test_mask_sqlmesh_runtime_tokens_avoids_source_marker_collisions():
+    sql = "SELECT __jsm0__ AS existing_marker, @run_dt AS run_dt"
+    masked, mapping = mask_sqlmesh_runtime_tokens(sql)
+    assert "@run_dt" not in masked
+    assert "__jsm0__ AS existing_marker" in masked
+    assert all(marker not in sql for marker in mapping)
+    assert unmask_sqlmesh_runtime_tokens(masked, mapping) == sql


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary
- Add SQLMesh-aware segmentation that preserves `MODEL`, `AUDIT`, virtual update markers, and opaque Jinja/SQLMesh blocks.
- Mask and restore inline Jinja expressions plus SQLMesh `@identifier` runtime tokens before `sqlglot` parsing.
- Format and lint real SQL segments only, with SQLMesh fixtures and regression coverage.

## Validation
- `mise run check`

Resolves #287
