### PR TITLE
fix: align modified star formatter blocks

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -878,7 +878,7 @@ FROM data
 
 ### `SELECT *` — rewritten as FROM-first
 
-`SELECT *` is rewritten to DuckDB's FROM-first syntax, omitting the `SELECT` clause entirely. Applies only when there are no JOINs.
+Plain, unmodified `SELECT *` is rewritten to DuckDB's FROM-first syntax, omitting the `SELECT` clause entirely. Applies only when there are no JOINs.
 
 **Bad**
 ```sql
@@ -901,6 +901,25 @@ FROM orders
 WHERE status = 'active'
 ORDER BY
    created_at
+;
+```
+
+Modified stars stay in `SELECT` form and expand their modifiers. `REPLACE` and `RENAME` keep jarify's alias alignment inside the modifier list.
+
+**Bad**
+```sql
+SELECT * RENAME (id AS vendor_id, name AS vendor_name) FROM orders
+```
+
+**Good**
+```sql
+SELECT
+   *
+   RENAME (
+      id   AS vendor_id
+     ,name AS vendor_name
+   )
+FROM orders
 ;
 ```
 
@@ -1054,7 +1073,7 @@ FROM sizes
 
 Flag top-level `SELECT *` and `table.*` in `SELECT` lists. `COUNT(*)` is exempt.
 
-When `prefer_from_first = true` (the default), single-table `SELECT *` queries are not flagged because the formatter already rewrites them to FROM-first syntax (`FROM t`). The rule still fires for `SELECT *` with JOINs, since those are not rewritten.
+When `prefer_from_first = true` (the default), only plain single-table `SELECT *` queries are exempt because the formatter rewrites them to FROM-first syntax (`FROM t`). Modified stars such as `SELECT * EXCLUDE (...)` and `SELECT * REPLACE (...)` are still flagged, as are `SELECT *` queries with JOINs.
 
 **Bad** (with `prefer_from_first = false`)
 ```sql

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -411,7 +411,7 @@ class JarifyGenerator(DuckDB.Generator):
         if not alias_name:
             return this_sql
         align_width = self._as_align_width
-        if align_width is not None and isinstance(expression.parent, exp.Select):
+        if align_width is not None and isinstance(expression.parent, (exp.Select, exp.Star)):
             if "\n" in this_sql:
                 lines = this_sql.splitlines()
                 visible_width = len(lines[-1].lstrip())
@@ -1134,7 +1134,7 @@ class JarifyGenerator(DuckDB.Generator):
         return super().in_sql(expression)
 
     # ------------------------------------------------------------------
-    # Star: keep * EXCLUDE / REPLACE / RENAME inline when it fits
+    # Star: expand EXCLUDE / REPLACE / RENAME as multi-line select content
     # ------------------------------------------------------------------
 
     def star_sql(self, expression: exp.Star) -> str:
@@ -1147,9 +1147,27 @@ class JarifyGenerator(DuckDB.Generator):
         rename_sql = f" RENAME ({rename})" if rename else ""
 
         inline = f"*{except_sql}{replace_sql}{rename_sql}"
-        if self.pretty and not self.too_wide([inline]):
-            return inline
-        return super().star_sql(expression)
+        has_modifiers = bool(except_ or replace or rename)
+        if not (self.pretty and has_modifiers):
+            return inline if self.pretty and not self.too_wide([inline]) else super().star_sql(expression)
+
+        lines = ["*"]
+        for keyword, key in ((self.STAR_EXCEPT, "except_"), ("REPLACE", "replace"), ("RENAME", "rename")):
+            saved_align = self._as_align_width
+            payload_expressions = list(expression.args.get(key) or [])
+            if key in ("replace", "rename"):
+                self._as_align_width = self._compute_as_align_width(payload_expressions)
+            try:
+                payload = self.expressions(expression, key=key, indent=False)
+            finally:
+                self._as_align_width = saved_align
+            if not payload:
+                continue
+            lines.append(f" {keyword} (")
+            lines.extend(f"   {line}" for line in payload.splitlines())
+            lines.append(" )")
+
+        return "\n".join(lines)
 
     # ------------------------------------------------------------------
     # Inequality operator: always emit != (never <>)
@@ -1184,14 +1202,16 @@ class JarifyGenerator(DuckDB.Generator):
             exprs = expression.expressions
             from_ = expression.args.get("from_")
 
+            star = exprs[0] if len(exprs) == 1 and isinstance(exprs[0], exp.Star) else None
+            plain_star = star is not None and not any(star.args.get(k) for k in ("except_", "replace", "rename"))
+
             # Detect VALUES-only CTE body: SELECT * FROM (VALUES ...) AS _values
             # sqlglot parses `WITH t(a,b) AS (VALUES ...)` into this shape; render
             # it back to a plain VALUES block instead of FROM (VALUES ...) AS _values.
             if (
                 self.pretty
                 and self._config.prefer_from_first
-                and len(exprs) == 1
-                and isinstance(exprs[0], exp.Star)
+                and plain_star
                 and not expression.args.get("distinct")
                 and not expression.args.get("joins")
                 and isinstance(from_, exp.From)
@@ -1213,8 +1233,6 @@ class JarifyGenerator(DuckDB.Generator):
                 and not j.args.get("using")
                 for j in joins
             )
-            star = exprs[0] if len(exprs) == 1 and isinstance(exprs[0], exp.Star) else None
-            plain_star = star is not None and not any(star.args.get(k) for k in ("except_", "replace", "rename"))
             if (
                 self.pretty
                 and self._config.prefer_from_first

--- a/src/jarify/rules/no_select_star.py
+++ b/src/jarify/rules/no_select_star.py
@@ -31,14 +31,19 @@ class NoSelectStarRule(LintOnlyRule):
                 isinstance(parent, exp.Column) and isinstance(parent.parent, exp.Select)
             ):
                 select = parent if isinstance(parent, exp.Select) else parent.parent
+                if not isinstance(select, exp.Select):
+                    continue
                 # When prefer_from_first is on, SELECT * FROM t gets rewritten to
                 # FROM t by the formatter. Linting the formatted output (FROM t)
                 # would re-parse to the same AST, so skip single-table star selects
                 # that the formatter already handles via FROM-first syntax.
+                star_expr = select.expressions[0] if len(select.expressions) == 1 else None
+                plain_star = isinstance(star_expr, exp.Star) and not any(
+                    star_expr.args.get(k) for k in ("except_", "replace", "rename")
+                )
                 if (
                     self.prefer_from_first
-                    and len(select.expressions) == 1
-                    and isinstance(select.expressions[0], exp.Star)
+                    and plain_star
                     and not select.args.get("distinct")
                     and not select.args.get("joins")
                 ):

--- a/tests/fixtures/select/from_first_star_qualified.expected.sql
+++ b/tests/fixtures/select/from_first_star_qualified.expected.sql
@@ -1,15 +1,26 @@
 SELECT
-   * EXCLUDE (sku_set_total_coverage)
+   *
+   EXCLUDE (
+      sku_set_total_coverage
+   )
 FROM _ordered
 WHERE sku_set_total_coverage > 0
 ;
 
 SELECT
-   * REPLACE (col + 1 AS col)
+   *
+   REPLACE (
+      col + 1             AS col
+     ,longer_col_name + 2 AS longer_col_name
+   )
 FROM _ordered
 ;
 
 SELECT
-   * RENAME (old_name AS new_name)
+   *
+   RENAME (
+      id   AS vendor_id
+     ,name AS vendor_name
+   )
 FROM _ordered
 ;

--- a/tests/fixtures/select/from_first_star_qualified.input.sql
+++ b/tests/fixtures/select/from_first_star_qualified.input.sql
@@ -1,3 +1,3 @@
 SELECT * EXCLUDE (sku_set_total_coverage) FROM _ordered WHERE sku_set_total_coverage > 0;
-SELECT * REPLACE (col + 1 AS col) FROM _ordered;
-SELECT * RENAME (old_name AS new_name) FROM _ordered;
+SELECT * REPLACE (col + 1 AS col, longer_col_name + 2 AS longer_col_name) FROM _ordered;
+SELECT * RENAME (id AS vendor_id, name AS vendor_name) FROM _ordered;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -274,6 +274,25 @@ class TestFromFirst:
         out, _ = format_sql("SELECT * FROM people", JarifyConfig(prefer_from_first=False))
         assert "SELECT" in out
 
+    def test_modified_star_keeps_select_and_expands_modifiers(self):
+        out, _ = format_sql(
+            "SELECT * EXCLUDE (a, b) REPLACE (x + 1 AS x, y + 2 AS y) "
+            "RENAME (old_name AS new_name, legacy_name AS display_name) FROM people"
+        )
+        assert out.startswith("SELECT")
+        assert "FROM people" in out
+        assert "   *\n   EXCLUDE (\n      a\n     ,b\n   )" in out
+        assert "   REPLACE (\n      x + 1 AS x\n     ,y + 2 AS y\n   )" in out
+        assert "   RENAME (\n      old_name    AS new_name\n     ,legacy_name AS display_name\n   )" in out
+
+    def test_modified_star_aligns_aliases_within_replace_and_rename(self):
+        out, _ = format_sql(
+            "SELECT * REPLACE (id + 1 AS vendor_id, name || suffix AS vendor_name) "
+            "RENAME (id AS vendor_id, name AS vendor_name) FROM vendors"
+        )
+        assert "      id + 1         AS vendor_id\n     ,name || suffix AS vendor_name" in out
+        assert "      id   AS vendor_id\n     ,name AS vendor_name" in out
+
 
 class TestLeftOuterJoinNormalization:
     def test_left_outer_join_normalized(self):

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -96,6 +96,11 @@ class TestNoSelectStar:
         rules = _lint("SELECT * FROM t JOIN u ON t.id = u.id", prefer_from_first=True)
         assert "no-select-star" in rules
 
+    def test_warns_on_modified_star_when_prefer_from_first_enabled(self):
+        # Modified stars are not rewritten to FROM-first, so they stay lint violations.
+        rules = _lint("SELECT * EXCLUDE (secret_col) FROM t", prefer_from_first=True)
+        assert "no-select-star" in rules
+
     def test_warns_when_prefer_from_first_disabled(self):
         # FROM t parses as SELECT * FROM t; should fire when prefer_from_first=False.
         rules = _lint("FROM t", prefer_from_first=False)


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.4) on behalf of @johnallen3d.

## Summary
- expand modified-star `EXCLUDE` / `REPLACE` / `RENAME` formatting into multi-line blocks
- keep alias alignment inside `REPLACE` and `RENAME` modifier lists
- limit FROM-first and `no-select-star` exemptions to plain unmodified `SELECT *`
- update fixtures, formatter/lint coverage, and the SQL style guide

## Validation
- `mise run check`

Resolves #293
