### PR TITLE
fix(generator): align AS keyword correctly for multi-line expressions

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -414,8 +414,12 @@ class JarifyGenerator(DuckDB.Generator):
         if align_width is not None and isinstance(expression.parent, (exp.Select, exp.Star)):
             if "\n" in this_sql:
                 lines = this_sql.splitlines()
-                visible_width = len(lines[-1].lstrip())
-                padding = " " * max(0, align_width - visible_width - 1)
+                # For multi-line expressions the last line (e.g. ``)``, ``END``)
+                # has no leader character prepended in the expressions loop
+                # (the `` ``/``,`` leader only goes on the first line).  To land
+                # ``AS`` at the same visual column as single-line aliases — which
+                # DO carry a 1-char leader — we add an extra +1 to the padding.
+                padding = " " * max(0, align_width - len(lines[-1]) + 1)
                 lines[-1] = f"{lines[-1]}{padding} AS {alias_name}"
                 return "\n".join(lines)
             padding = " " * max(0, align_width - len(this_sql))

--- a/tests/fixtures/conditionals/prefer_if_over_case.expected.sql
+++ b/tests/fixtures/conditionals/prefer_if_over_case.expected.sql
@@ -9,10 +9,10 @@ SELECT
      WHEN a = 2
      THEN 'two'
      ELSE 'other'
-   END                        AS label
+   END                         AS label
   ,CASE a
     WHEN 1 THEN 'one'
     ELSE 'other'
-  END                        AS simple_case
+  END                          AS simple_case
 FROM t
 ;

--- a/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment.expected.sql
+++ b/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment.expected.sql
@@ -1,0 +1,8 @@
+SELECT
+   list_transform(
+     very_long_array_column_name_here
+    ,s -> {'sku_set_id': s.sku_set_id, 'label': s.label, 'status': s.status, 'created_at': s.created_at}
+  )                                                   AS sku_sets
+  ,ifnull(incentive -> 'stacks', '[]'::json)::stack[] AS stacks
+FROM t
+;

--- a/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment.input.sql
+++ b/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment.input.sql
@@ -1,0 +1,5 @@
+SELECT
+   list_transform(very_long_array_column_name_here, s -> struct_pack(sku_set_id := s.sku_set_id, label := s.label, status := s.status, created_at := s.created_at)) AS sku_sets
+  ,ifnull(incentive -> 'stacks', '[]'::json)::stack[] AS stacks
+FROM t
+;

--- a/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment_idempotency.expected.sql
+++ b/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment_idempotency.expected.sql
@@ -1,0 +1,8 @@
+SELECT
+   list_transform(
+     very_long_array_column_name_here
+    ,s -> {'sku_set_id': s.sku_set_id, 'label': s.label, 'status': s.status, 'created_at': s.created_at}
+  )                                                   AS sku_sets
+  ,ifnull(incentive -> 'stacks', '[]'::json)::stack[] AS stacks
+FROM t
+;

--- a/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment_idempotency.input.sql
+++ b/tests/fixtures/duckdb/multiline_closing_paren_alias_alignment_idempotency.input.sql
@@ -1,0 +1,8 @@
+SELECT
+   list_transform(
+     very_long_array_column_name_here
+    ,s -> {'sku_set_id': s.sku_set_id, 'label': s.label, 'status': s.status, 'created_at': s.created_at}
+  )                                                   AS sku_sets
+  ,ifnull(incentive -> 'stacks', '[]'::json)::stack[] AS stacks
+FROM t
+;

--- a/tests/fixtures/select/alias_alignment_mixed_multiline.expected.sql
+++ b/tests/fixtures/select/alias_alignment_mixed_multiline.expected.sql
@@ -8,6 +8,6 @@ SELECT
      WHEN a.x = 2
      THEN 'no'
      ELSE 'maybe'
-   END              AS category
+   END               AS category
 FROM t a
 ;

--- a/tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.expected.sql
+++ b/tests/fixtures/select/alias_alignment_mixed_multiline_idempotency.expected.sql
@@ -8,6 +8,6 @@ SELECT
      WHEN a.x = 2
      THEN 'no'
      ELSE 'maybe'
-   END              AS category
+   END               AS category
 FROM t a
 ;

--- a/tests/fixtures/select/case_when_better_handling.expected.sql
+++ b/tests/fixtures/select/case_when_better_handling.expected.sql
@@ -7,7 +7,7 @@ SELECT
       AND baq
      THEN world
      ELSE NULL
-   END        AS abc
+   END         AS abc
   ,CASE
      WHEN foo
      THEN bar
@@ -15,6 +15,6 @@ SELECT
        OR hello
      THEN world
      ELSE NULL
-   END        AS def
+   END         AS def
 FROM data
 ;

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -122,7 +122,7 @@ FROM data
     result, _ = format_sql(sql)
     assert "\n     WHEN foo\n     THEN bar\n" in result
     assert "\n     WHEN baz\n      AND baq\n     THEN world\n" in result
-    assert "\n   END        AS abc\n" in result
+    assert "\n   END         AS abc\n" in result
 
 
 def test_parse_failure_returns_original_with_warning():


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by Pi (GitHub Copilot claude-sonnet-4.6) on behalf of @johnallen3d.

## Summary

Fixes a 2-column misalignment of the `AS` keyword when a SELECT list mixes multi-line expressions (closing `)` or `END`) with single-line aliases.

### Root cause

`alias_sql` uses two different code paths for padding:

- **Single-line**: `padding = align_width - len(this_sql)` → `AS` lands at column `align_width`
- **Multi-line**: `padding = align_width - visible_width - 1` → `AS` lands at column `align_width - 2`

The off-by-two comes from the fact that multi-line last lines (e.g. `)`, `END`) are written into `result_sqls` **without** a leader character — the ` `/`,` leader is only prepended to the *first* line of the multi-line entry. Single-line entries always carry a 1-char leader. To compensate, the multi-line padding needs `+1`, not `-1`.

### Fix

```python
# Before
visible_width = len(lines[-1].lstrip())
padding = " " * max(0, align_width - visible_width - 1)

# After
padding = " " * max(0, align_width - len(lines[-1]) + 1)
```

### Before / After

```sql
-- Before (AS misaligned by 2 columns on ) line)
SELECT
   list_transform(
     ...
  )                                                 AS sku_sets        -- col 51
  ,ifnull(incentive -> 'stacks', '[]'::json)::stack[] AS stacks        -- col 53

-- After (both AS at same column)
SELECT
   list_transform(
     ...
  )                                                   AS sku_sets      -- col 53
  ,ifnull(incentive -> 'stacks', '[]'::json)::stack[] AS stacks        -- col 53
```

The same fix corrects `CASE … END AS alias` alignment (was 1 column off due to 1 leading space on the `END` line).

## Changes

- `src/jarify/generator.py` — fix padding formula in `alias_sql` multi-line path
- `tests/test_formatter.py` — update `test_searched_case_issue_260_layout_is_preserved` to expect correct (1 column wider) alignment
- `tests/fixtures/duckdb/multiline_closing_paren_alias_alignment.*` — new fixture pair covering the closing-paren case
- `tests/fixtures/duckdb/multiline_closing_paren_alias_alignment_idempotency.*` — idempotency fixture
- Various existing `CASE…END` fixtures updated to reflect the corrected 1-column alignment

Resolves #296
