### PR TITLE
fix(generator): fix AS alias alignment for multi-line expressions and macro wrappers

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
 [tools]
-uv = "latest"
+# uv pinned: 0.11.9 was published manually (crates.io timeout) and explicitly
+# lacks GitHub attestations. check-uv-pin.yml polls weekly and will auto-PR to
+# restore "latest" once attestations pass. See: amfaro/calc#3232
+uv = "0.11.8"
 git-cliff = "latest"
 
 [env]

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -357,6 +357,11 @@ class JarifyGenerator(DuckDB.Generator):
         Query-wide alignment spans the main SELECT plus any CTE-body SELECTs,
         including nested CTEs. It intentionally excludes unrelated subqueries in
         expressions or JOINs, which keep their local alignment behavior.
+
+        When ``expression`` is not itself a SELECT (e.g. a CREATE MACRO wrapping
+        a ``WITH … SELECT`` body) we walk into the statement to find the inner
+        SELECT that owns the top-level WITH clause, then recurse from there so
+        that all CTEs inside the statement share a single alignment column.
         """
         if isinstance(expression, exp.Select):
             yield expression
@@ -365,6 +370,14 @@ class JarifyGenerator(DuckDB.Generator):
                 for cte in with_.expressions:
                     if isinstance(cte, exp.CTE) and isinstance(cte.this, exp.Select):
                         yield from self._iter_query_aligned_selects(cte.this)
+        else:
+            # Non-Select wrapper (e.g. CREATE OR REPLACE MACRO … AS TABLE (…)):
+            # find the inner SELECT that owns the WITH clause and treat it as
+            # the root of the query-aligned tree.
+            for node in expression.walk():
+                if isinstance(node, exp.Select) and node.args.get("with_"):
+                    yield from self._iter_query_aligned_selects(node)
+                    return
 
     def _select_expression_prefix_width(self, select: exp.Select) -> int:
         """Return visible prefix width before a SELECT-list expression.
@@ -383,15 +396,37 @@ class JarifyGenerator(DuckDB.Generator):
         return self.pad + 1 + (ancestor_selects * self._indent)
 
     def _collect_as_alignment_metrics(self, expressions_list: list) -> tuple[list[int], int]:
-        """Return ``(column_widths, alias_count)`` for a SELECT expression list."""
+        """Return ``(column_widths, alias_count)`` for a SELECT expression list.
+
+        For single-line aliased expressions the width is simply ``len(col_sql)``.
+        For multi-line aliased expressions (e.g. scalar subqueries, CASE blocks)
+        the effective width is ``max(0, len(last_line.lstrip()) - 1)``.
+
+        The ``-1`` adjustment exists because ``alias_sql`` adds ``+1`` to the
+        padding for multi-line expressions in order to compensate for the
+        missing leader character on continuation lines (the `` ``/``,`` leader
+        is only prepended to the *first* line of an expression by the
+        ``expressions()`` loop, not subsequent lines including the last).  When
+        a SELECT list contains *only* multi-line expressions there is no
+        single-line expression to drive ``align_width`` higher, so without the
+        ``-1`` correction the ``+1`` in ``alias_sql`` causes a spurious extra
+        space before ``AS`` (yielding ``), 1)  AS alias`` instead of the
+        expected ``), 1) AS alias``).
+        """
         col_widths: list[int] = []
         alias_count = 0
         for e in expressions_list:
             if isinstance(e, exp.Alias):
                 alias_count += 1
                 col_sql = self.sql(e.this)
-                last_line = col_sql.splitlines()[-1]
-                col_widths.append(len(last_line.lstrip() if "\n" in col_sql else last_line))
+                if "\n" in col_sql:
+                    last_line = col_sql.splitlines()[-1]
+                    # Subtract 1: cancels the +1 compensation in alias_sql so that
+                    # SELECT lists with only multi-line expressions don't produce a
+                    # spurious extra space before AS.
+                    col_widths.append(max(0, len(last_line.lstrip()) - 1))
+                else:
+                    col_widths.append(len(col_sql))
             else:
                 # Non-aliased single-line columns count toward the alignment
                 # width so AS keywords clear the longest expression in the list.

--- a/tests/fixtures/cte/alias_alignment_macro_wrapper.expected.sql
+++ b/tests/fixtures/cte/alias_alignment_macro_wrapper.expected.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE MACRO example_macro
+(
+   _op
+) AS TABLE
+(
+  WITH _wide AS
+  (
+    SELECT
+       very_long_function_call(a, b, c) AS wide_result
+      ,short                            AS x
+    FROM t
+  )
+  ,_narrow AS
+  (
+    SELECT
+       _wide.wide_result                AS result
+      ,_wide.x                          AS letter
+    FROM _wide
+  )
+  FROM _narrow
+)
+;

--- a/tests/fixtures/cte/alias_alignment_macro_wrapper.input.sql
+++ b/tests/fixtures/cte/alias_alignment_macro_wrapper.input.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE MACRO example_macro(_op) AS TABLE
+(
+  WITH _wide AS
+  (
+    SELECT
+       very_long_function_call(a, b, c) AS wide_result
+      ,short                            AS x
+    FROM t
+  )
+  ,_narrow AS
+  (
+    SELECT
+       _wide.wide_result AS result
+      ,_wide.x           AS letter
+    FROM _wide
+  )
+  FROM _narrow
+)

--- a/tests/fixtures/cte/alias_alignment_multiline_subquery.expected.sql
+++ b/tests/fixtures/cte/alias_alignment_multiline_subquery.expected.sql
@@ -1,0 +1,27 @@
+WITH _actual AS
+(
+  SELECT
+     _numerator_total.amount / ifnull((
+      SELECT
+         divisor
+      FROM _variant_divisors
+      WHERE context = 'numerator'
+    ), 1)                       AS numerator_amount
+    ,_denominator_total.amount / ifnull((
+      SELECT
+         divisor
+      FROM _variant_divisors
+      WHERE context = 'denominator'
+    ), 1)                       AS denominator_amount
+  FROM _numerator_total
+  CROSS JOIN _denominator_total
+)
+,_result AS
+(
+  SELECT
+     _actual.numerator_amount   AS numerator
+    ,_actual.denominator_amount AS denominator
+  FROM _actual
+)
+FROM _result
+;

--- a/tests/fixtures/cte/alias_alignment_multiline_subquery.input.sql
+++ b/tests/fixtures/cte/alias_alignment_multiline_subquery.input.sql
@@ -1,0 +1,18 @@
+WITH _actual AS (
+  SELECT
+     _numerator_total.amount / ifnull((
+      SELECT divisor FROM _variant_divisors WHERE context = 'numerator'
+    ), 1) AS numerator_amount
+    ,_denominator_total.amount / ifnull((
+      SELECT divisor FROM _variant_divisors WHERE context = 'denominator'
+    ), 1) AS denominator_amount
+  FROM _numerator_total
+  CROSS JOIN _denominator_total
+)
+,_result AS (
+  SELECT
+     _actual.numerator_amount AS numerator
+    ,_actual.denominator_amount AS denominator
+  FROM _actual
+)
+SELECT * FROM _result

--- a/tests/fixtures/select/alias_alignment_multiline_subquery.expected.sql
+++ b/tests/fixtures/select/alias_alignment_multiline_subquery.expected.sql
@@ -1,0 +1,16 @@
+SELECT
+   _numerator_total.amount / ifnull((
+    SELECT
+       divisor
+    FROM _variant_divisors
+    WHERE context = 'numerator'
+  ), 1) AS numerator_amount
+  ,_denominator_total.amount / ifnull((
+    SELECT
+       divisor
+    FROM _variant_divisors
+    WHERE context = 'denominator'
+  ), 1) AS denominator_amount
+FROM _numerator_total
+CROSS JOIN _denominator_total
+;

--- a/tests/fixtures/select/alias_alignment_multiline_subquery.input.sql
+++ b/tests/fixtures/select/alias_alignment_multiline_subquery.input.sql
@@ -1,0 +1,9 @@
+SELECT
+   _numerator_total.amount / ifnull((
+    SELECT divisor FROM _variant_divisors WHERE context = 'numerator'
+  ), 1) AS numerator_amount
+  ,_denominator_total.amount / ifnull((
+    SELECT divisor FROM _variant_divisors WHERE context = 'denominator'
+  ), 1) AS denominator_amount
+FROM _numerator_total
+CROSS JOIN _denominator_total


### PR DESCRIPTION
 > [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary

Two independent AS alias alignment bugs fixed together.

### Bug 1 — spurious extra space before `AS` in all-multi-line SELECT lists

In a SELECT where every aliased expression is multi-line (e.g. scalar subquery inside `ifnull()`), `alias_sql` pads with a spurious extra space when the alignment column is driven by those same multi-line expressions — producing `), 1)  AS alias` instead of `), 1) AS alias`.

Root cause: `_collect_as_alignment_metrics` measured multi-line width as `len(last_line.lstrip())`. `alias_sql` adds `+1` to compensate for the missing leader character on continuation lines; when all expressions are multi-line that `+1` is never cancelled.

Fix: subtract 1 from multi-line widths in `_collect_as_alignment_metrics` so the compensation is absorbed by the calculation, not by padding.

> **Note:** in `tmp/example.sql` this bug is subsumed by bug 2 — the alignment column is driven by the wide single-line `ifnull(SUM(…), 0)` expression, so the extra space never appeared there. Bug 1 is independently observable in a standalone SELECT whose entire expression list is multi-line.

### Bug 2 — tree-wide AS alignment skipped inside `CREATE MACRO` wrappers

`_threshold` and `_result` aligned their `AS` keywords to different columns because tree-wide alignment never fired for the macro body. Each CTE produced its own local alignment independently.

Root cause: `_iter_query_aligned_selects` only entered the CTE tree when the top-level expression was a bare `SELECT`. `CREATE OR REPLACE MACRO … AS TABLE (…)` wraps the inner query as `Create → Subquery → Select`, so the walk returned nothing.

Fix: when the top-level is not a `Select`, walk into the statement to find the inner `Select` that owns the `WITH` clause and recurse from there — the same tree-wide alignment that already worked for standalone `WITH … SELECT` now applies inside macros too.

### Changed files

| File | Change |
|------|--------|
| `src/jarify/generator.py` | `-1` adjustment in `_collect_as_alignment_metrics`; non-Select traversal in `_iter_query_aligned_selects` |
| `tests/fixtures/select/alias_alignment_multiline_subquery.*` | Standalone SELECT reproducer for bug 1 |
| `tests/fixtures/cte/alias_alignment_multiline_subquery.*` | CTE fixture: mixed multi-line + single-line tree-wide alignment |
| `tests/fixtures/cte/alias_alignment_macro_wrapper.*` | Macro wrapper fixture for bug 2 |
| `mise.toml` | Pin `uv` to `0.11.8` (build fix) |

### Verification

```
mise run check   # 306 passed, lint clean
```

Resolves #299
