### PR TITLE
fix(generator): prefer list() over ARRAY_AGG for DuckDB canonical aggregate

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -97,7 +97,7 @@ FROM t
 
 ### Built-in function aliases — canonical DuckDB names
 
-Built-in aliases are normalized to jarify's canonical DuckDB names. In practice that means `listagg(...)` becomes `STRING_AGG(...)`, and `array_contains(...)` becomes `list_contains(...)`.
+Built-in aliases are normalized to jarify's canonical DuckDB names. In practice that means `listagg(...)` becomes `STRING_AGG(...)`, and `array_contains(...)` becomes `list_contains(...)`. `array_agg(...)` is also normalized — see below.
 
 **Bad**
 ```sql
@@ -110,6 +110,37 @@ SELECT
    STRING_AGG(code, ' | ')  AS codes
   ,list_contains(tags, 'x') AS has_tag
 FROM t
+;
+```
+
+---
+
+### `array_agg()` → `list()` — canonical DuckDB aggregate
+
+In DuckDB, `list()` is the canonical aggregate function; `array_agg()` is an alias. Jarify rewrites all `array_agg(...)` calls to `list(...)` regardless of arguments.
+
+**Bad**
+```sql
+SELECT array_agg(x) FROM t;
+SELECT array_agg(x ORDER BY y) FROM t;
+SELECT array_agg(DISTINCT x) FROM t GROUP BY z;
+```
+
+**Good**
+```sql
+SELECT
+   list(x)
+FROM t
+;
+SELECT
+   list(x ORDER BY y)
+FROM t
+;
+SELECT
+   list(DISTINCT x)
+FROM t
+GROUP BY
+   z
 ;
 ```
 
@@ -809,7 +840,7 @@ FROM sku_composition
 
 ### `DISTINCT` inside aggregates — own line when wrapping
 
-When `ARRAY_AGG(DISTINCT expr ...)` wraps across lines, `DISTINCT` appears on its own line.
+When `list(DISTINCT expr ...)` wraps across lines, `DISTINCT` appears on its own line.
 
 **Bad**
 ```sql
@@ -819,7 +850,7 @@ SELECT ARRAY_AGG(DISTINCT (active_ingredient_key, quantity, uom_key)::active_ing
 **Good**
 ```sql
 SELECT
-   ARRAY_AGG(
+   list(
     DISTINCT (
        active_ingredient_key
       ,quantity

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -1483,24 +1483,56 @@ class JarifyGenerator(DuckDB.Generator):
         return f"{params} {arrow_sep}\n{indented_body}"
 
     # ------------------------------------------------------------------
-    # ArrayAgg with DISTINCT: put DISTINCT on its own line when wrapping
+    # ArrayAgg → list(): DuckDB canonical aggregate name
+    # array_agg() is an alias; jarify always emits list() regardless of input.
+    # Also handles DISTINCT with wrapping when pretty-printing.
+    # list_sql handles the same wrapping for List nodes (idempotency: list(DISTINCT ...)
+    # re-parses as exp.List, not exp.ArrayAgg).
     # ------------------------------------------------------------------
 
     def arrayagg_sql(self, expression: exp.ArrayAgg) -> str:
+        func_name = self.normalize_func("list")
         if not (self.pretty and isinstance(expression.this, exp.Distinct)):
-            return super().arrayagg_sql(expression)
+            # Non-DISTINCT or compact mode: emit list(<inner>)
+            inner = self.sql(expression, "this")
+            list_sql = f"{func_name}({inner})"
+            return self._add_arrayagg_null_filter(list_sql, expression, expression.this)
         distinct = expression.this
         exprs_sqls = [self.sql(e) for e in distinct.expressions]
-        func_name = self.normalize_func("ARRAY_AGG")
         # Wrap when any expression is already multi-line, or when the flat inline is too wide
         any_multiline = any("\n" in s for s in exprs_sqls)
         flat_inline = f"{func_name}(DISTINCT {', '.join(exprs_sqls)})"
         if not any_multiline and not self.too_wide([flat_inline]):
-            return super().arrayagg_sql(expression)
+            # Fits inline — emit list(DISTINCT <exprs>)
+            inner = self.sql(expression, "this")
+            list_sql = f"{func_name}({inner})"
+            return self._add_arrayagg_null_filter(list_sql, expression, expression.this)
         exprs_str = "\n".join(exprs_sqls)
         inner = self.indent(f"\nDISTINCT {exprs_str}\n", skip_first=True, skip_last=True)
-        array_agg_sql = f"{func_name}({inner})"
-        return self._add_arrayagg_null_filter(array_agg_sql, expression, expression.this)
+        list_sql = f"{func_name}({inner})"
+        return self._add_arrayagg_null_filter(list_sql, expression, expression.this)
+
+    def list_sql(self, expression: exp.List) -> str:
+        """Handle exp.List with DISTINCT wrapping (mirrors arrayagg_sql for idempotency).
+
+        list(DISTINCT ...) re-parses as exp.List (not exp.ArrayAgg), so this
+        method must apply the same DISTINCT-wrapping logic to keep formatting
+        stable across multiple passes.
+        """
+        func_name = self.normalize_func("list")
+        # expressions[0] is Distinct when written as list(DISTINCT ...)
+        distinct = expression.expressions[0] if expression.expressions else None
+        if not (self.pretty and isinstance(distinct, exp.Distinct)):
+            # Non-DISTINCT or compact mode: delegate to default
+            return super().function_fallback_sql(expression)
+        exprs_sqls = [self.sql(e) for e in distinct.expressions]
+        any_multiline = any("\n" in s for s in exprs_sqls)
+        flat_inline = f"{func_name}(DISTINCT {', '.join(exprs_sqls)})"
+        if not any_multiline and not self.too_wide([flat_inline]):
+            return super().function_fallback_sql(expression)
+        exprs_str = "\n".join(exprs_sqls)
+        inner = self.indent(f"\nDISTINCT {exprs_str}\n", skip_first=True, skip_last=True)
+        return f"{func_name}({inner})"
 
     def format_args(self, *args: t.Any, sep: str = ", ") -> str:
         arg_sqls = tuple(self.sql(arg) for arg in args if arg is not None and not isinstance(arg, bool))

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -1492,25 +1492,21 @@ class JarifyGenerator(DuckDB.Generator):
 
     def arrayagg_sql(self, expression: exp.ArrayAgg) -> str:
         func_name = self.normalize_func("list")
-        if not (self.pretty and isinstance(expression.this, exp.Distinct)):
-            # Non-DISTINCT or compact mode: emit list(<inner>)
-            inner = self.sql(expression, "this")
-            list_sql = f"{func_name}({inner})"
-            return self._add_arrayagg_null_filter(list_sql, expression, expression.this)
-        distinct = expression.this
-        exprs_sqls = [self.sql(e) for e in distinct.expressions]
-        # Wrap when any expression is already multi-line, or when the flat inline is too wide
-        any_multiline = any("\n" in s for s in exprs_sqls)
-        flat_inline = f"{func_name}(DISTINCT {', '.join(exprs_sqls)})"
-        if not any_multiline and not self.too_wide([flat_inline]):
-            # Fits inline — emit list(DISTINCT <exprs>)
-            inner = self.sql(expression, "this")
-            list_sql = f"{func_name}({inner})"
-            return self._add_arrayagg_null_filter(list_sql, expression, expression.this)
-        exprs_str = "\n".join(exprs_sqls)
-        inner = self.indent(f"\nDISTINCT {exprs_str}\n", skip_first=True, skip_last=True)
-        list_sql = f"{func_name}({inner})"
-        return self._add_arrayagg_null_filter(list_sql, expression, expression.this)
+        distinct = expression.this if isinstance(expression.this, exp.Distinct) else None
+        if self.pretty and distinct is not None:
+            exprs_sqls = [self.sql(e) for e in distinct.expressions]
+            # Wrap when any expression is already multi-line, or when the flat inline is too wide
+            any_multiline = any("\n" in s for s in exprs_sqls)
+            flat_inline = f"{func_name}(DISTINCT {', '.join(exprs_sqls)})"
+            if any_multiline or self.too_wide([flat_inline]):
+                exprs_str = "\n".join(exprs_sqls)
+                inner = self.indent(f"\nDISTINCT {exprs_str}\n", skip_first=True, skip_last=True)
+                result = f"{func_name}({inner})"
+                return self._add_arrayagg_null_filter(result, expression, expression.this)
+        # Non-DISTINCT, compact mode, or DISTINCT that fits inline: emit list(<inner>)
+        inner = self.sql(expression, "this")
+        result = f"{func_name}({inner})"
+        return self._add_arrayagg_null_filter(result, expression, expression.this)
 
     def list_sql(self, expression: exp.List) -> str:
         """Handle exp.List with DISTINCT wrapping (mirrors arrayagg_sql for idempotency).

--- a/tests/fixtures/duckdb/array_agg_normalized_to_list.expected.sql
+++ b/tests/fixtures/duckdb/array_agg_normalized_to_list.expected.sql
@@ -26,3 +26,10 @@ SELECT
    list(x ORDER BY y)
 FROM t
 ;
+
+SELECT
+   list(DISTINCT x)
+FROM t
+GROUP BY
+   z
+;

--- a/tests/fixtures/duckdb/array_agg_normalized_to_list.expected.sql
+++ b/tests/fixtures/duckdb/array_agg_normalized_to_list.expected.sql
@@ -1,0 +1,28 @@
+-- array_agg() is an alias; jarify normalizes to list()
+SELECT
+   list(x)
+FROM t
+;
+
+SELECT
+   list(x ORDER BY y)
+FROM t
+;
+
+SELECT
+   list(DISTINCT x)
+FROM t
+GROUP BY
+   z
+;
+
+-- list() passthrough — no change
+SELECT
+   list(x)
+FROM t
+;
+
+SELECT
+   list(x ORDER BY y)
+FROM t
+;

--- a/tests/fixtures/duckdb/array_agg_normalized_to_list.input.sql
+++ b/tests/fixtures/duckdb/array_agg_normalized_to_list.input.sql
@@ -1,0 +1,7 @@
+-- array_agg() is an alias; jarify normalizes to list()
+SELECT array_agg(x) FROM t;
+SELECT array_agg(x ORDER BY y) FROM t;
+SELECT array_agg(DISTINCT x) FROM t GROUP BY z;
+-- list() passthrough — no change
+SELECT list(x) FROM t;
+SELECT list(x ORDER BY y) FROM t;

--- a/tests/fixtures/duckdb/array_agg_normalized_to_list.input.sql
+++ b/tests/fixtures/duckdb/array_agg_normalized_to_list.input.sql
@@ -5,3 +5,4 @@ SELECT array_agg(DISTINCT x) FROM t GROUP BY z;
 -- list() passthrough — no change
 SELECT list(x) FROM t;
 SELECT list(x ORDER BY y) FROM t;
+SELECT list(DISTINCT x) FROM t GROUP BY z;

--- a/tests/fixtures/duckdb/distinct_in_aggregates.expected.sql
+++ b/tests/fixtures/duckdb/distinct_in_aggregates.expected.sql
@@ -1,5 +1,5 @@
 SELECT
-   ARRAY_AGG(
+   list(
     DISTINCT (
        active_ingredient_key
       ,quantity

--- a/tests/fixtures/duckdb/struct_cast_field_alignment.expected.sql
+++ b/tests/fixtures/duckdb/struct_cast_field_alignment.expected.sql
@@ -1,6 +1,6 @@
 SELECT
    sku_key
-  ,ARRAY_AGG((
+  ,list((
      key
     ,'string'
     ,value

--- a/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
+++ b/tests/fixtures/templates/rust_fmt_placeholder_ambiguous_cte_anchor.expected.sql
@@ -5,11 +5,11 @@ WITH _sku_catalog AS
 ,_aggregated_and_sorted AS
 (
   SELECT
-     ARRAY_AGG((f) ORDER BY key) AS skus
+     list((f) ORDER BY key) AS skus
   FROM _final f
   {manufacturer_filter}
 )
 SELECT
-   skus::json                    AS skus
+   skus::json               AS skus
 FROM _aggregated_and_sorted
 ;


### PR DESCRIPTION
 > [!NOTE]
> This PR description was authored by Pi (OpenAI Codex gpt-5.5) on behalf of @johnallen3d.

## Summary

Fixes #302 — `array_agg()` is a DuckDB compatibility alias; `list()` is the canonical aggregate function. Jarify was emitting `ARRAY_AGG` for all `ArrayAgg` nodes regardless of input.

### Changes

- **`src/jarify/generator.py`** — rewrote `arrayagg_sql` to emit `list` via `normalize_func("list")` in all paths (inline, `DISTINCT`-inline, `DISTINCT`-wrapped). Added `list_sql` to apply the same `DISTINCT`-wrapping logic for `exp.List` nodes, ensuring idempotency when already-formatted `list(DISTINCT ...)` output is re-formatted (it re-parses as `exp.List`, not `exp.ArrayAgg`). Collapsed duplicate early-return blocks for clarity.
- **Updated 3 fixtures** that expected `ARRAY_AGG` output: `distinct_in_aggregates`, `struct_cast_field_alignment`, `rust_fmt_placeholder_ambiguous_cte_anchor`.
- **Added new fixture** `array_agg_normalized_to_list` — covers `array_agg()` → `list()` rewrite for plain, `ORDER BY`, and `DISTINCT` variants, plus `list()` and `list(DISTINCT x)` passthroughs (the latter exercises the `list_sql` path directly).
- **`docs/sql-style-guide.md`** — added `array_agg() → list()` rule section with bad/good examples; updated the `DISTINCT inside aggregates` section to show `list()` instead of `ARRAY_AGG()`.

### Verification

```
307 passed in 0.36s
```

Resolves #302
