### PR TITLE
docs: remove nvarchar reference from style guide

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -1183,16 +1183,16 @@ Flag non-canonical DuckDB type names. Use the canonical form instead.
 | Non-canonical | Canonical |
 |---------------|-----------|
 | `float`, `float4` | `real` |
-| `varchar`, `nvarchar` | `text` |
+| `varchar` | `text` |
 
 **Bad**
 ```sql
-CREATE TABLE t (score FLOAT, short_label VARCHAR, long_label NVARCHAR)
+CREATE TABLE t (score FLOAT, short_label VARCHAR)
 ```
 
 **Good**
 ```sql
-CREATE TABLE t (score real, short_label text, long_label text)
+CREATE TABLE t (score real, short_label text)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Remove invalid `nvarchar` type reference from the `duckdb-type-style` rule documentation.

DuckDB does not support `nvarchar` — it's an invalid data type. The docs incorrectly listed it alongside `varchar` as a non-canonical type that requires conversion. 

Now the docs accurately reflect that only:
- `varchar` (and `float`/`float4`) need conversion
- To canonical `text` and `real` respectively

## Changes
- Remove `nvarchar` from the non-canonical types table in the `duckdb-type-style` rule docs
- Update bad/good code examples to remove references to `NVARCHAR`

## Validation
- ✅ All 307 tests pass
- ✅ Linter passes (`mise run check`)
- ✅ Docs now accurate to DuckDB capabilities

Resolves #306