### PR TITLE
feat(rules): add cross-join-with-where-condition lint rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,6 +21,7 @@ examples see [`sql-style-guide.md`](sql-style-guide.md).
 | `trailing-commas` | `trailing_commas` | off | yes | trailing comma placement (default: leading commas) |
 | `no-implicit-cross-join` | `no_implicit_cross_join` | warn | yes | rewrite implicit cross joins to explicit CROSS JOIN |
 | `explicit-cross-join-needs-condition` | `explicit_cross_join_needs_condition` | warn | no | flag explicit CROSS JOINs without ON/USING clauses |
+| `cross-join-with-where-condition` | `cross_join_with_where_condition` | error | no | flag CROSS JOINs with WHERE clauses connecting multiple tables (should be INNER JOIN) |
 | `no-select-star` | `no_select_star` | warn | no | flag SELECT * usage, including inside CTE bodies |
 | `no-unused-cte` | `no_unused_cte` | warn | no | flag CTEs that are defined but never referenced |
 | `duckdb-type-style` | `duckdb_type_style` | warn | no | prefer canonical DuckDB type names (e.g. int not integer) |

--- a/src/jarify/config.py
+++ b/src/jarify/config.py
@@ -36,6 +36,7 @@ class JarifyConfig:
     no_select_star: str = "warn"
     no_implicit_cross_join: str = "warn"
     explicit_cross_join_needs_condition: str = "warn"
+    cross_join_with_where_condition: str = "error"
     no_unused_cte: str = "warn"
 
     # --- DuckDB-specific lint rules ---

--- a/src/jarify/rules/__init__.py
+++ b/src/jarify/rules/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from jarify.rules.base import FormatterRule
 from jarify.rules.consistent_empty_array import ConsistentEmptyArrayRule
+from jarify.rules.cross_join_with_where_condition import CrossJoinWithWhereConditionRule
 from jarify.rules.cte_naming import CteNamingRule
 from jarify.rules.duckdb_prefer_qualify import DuckdbPreferQualifyRule
 from jarify.rules.duckdb_type_style import DuckdbTypeStyleRule
@@ -72,6 +73,13 @@ RULE_CATALOG: list[RuleInfo] = [
         default="warn",
         auto_fix=False,
         description="flag explicit CROSS JOINs without ON/USING clauses",
+    ),
+    RuleInfo(
+        name="cross-join-with-where-condition",
+        config_key="cross_join_with_where_condition",
+        default="error",
+        auto_fix=False,
+        description="flag CROSS JOINs with WHERE clauses connecting multiple tables (should be INNER JOIN)",
     ),
     RuleInfo(
         name="no-select-star",
@@ -184,6 +192,10 @@ def get_default_rules(config: JarifyConfig, overrides: CommentOverrides | None =
             ExplicitCrossJoinNeedsConditionRule(
                 severity=config.explicit_cross_join_needs_condition, overrides=overrides
             )
+        )
+    if config.cross_join_with_where_condition != "off":
+        rules.append(
+            CrossJoinWithWhereConditionRule(severity=config.cross_join_with_where_condition, overrides=overrides)
         )
 
     # --- DuckDB-specific lint rules ---

--- a/src/jarify/rules/cross_join_with_where_condition.py
+++ b/src/jarify/rules/cross_join_with_where_condition.py
@@ -66,7 +66,7 @@ class CrossJoinWithWhereConditionRule(LintOnlyRule):
     should be rewritten as an INNER JOIN with an ON clause.
     """
 
-    def __init__(self, severity: str = "warn", overrides=None) -> None:
+    def __init__(self, severity: str = "error", overrides=None) -> None:
         super().__init__(overrides=overrides)
         self.severity = severity
 

--- a/src/jarify/rules/cross_join_with_where_condition.py
+++ b/src/jarify/rules/cross_join_with_where_condition.py
@@ -1,0 +1,120 @@
+"""Rule: flag CROSS JOINs with WHERE clause that connects multiple tables."""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+
+from jarify.rules.base import LintOnlyRule, _node_pos
+from jarify.types import LintViolation
+
+
+def _extract_table_refs(expr: exp.Expression) -> set[str | None]:
+    """Extract all table references from an expression (qualified column names)."""
+    tables = set()
+    for col in expr.find_all(exp.Column):
+        # Get the table part of a qualified column (e.g., 'a' from 'a.id')
+        if col.table:
+            tables.add(col.table)
+        else:
+            # Unqualified column; treat as potentially cross-table
+            tables.add(None)
+    return tables
+
+
+def _is_join_condition(expr: exp.Expression) -> bool:
+    """
+    Check if an expression is a join condition (equality between columns from different tables).
+    Returns True if expr is `col1 = col2` where col1 and col2 have different table refs.
+    """
+    if not isinstance(expr, exp.EQ):
+        return False
+    left_tables = _extract_table_refs(expr.left)
+    right_tables = _extract_table_refs(expr.right)
+    # A join condition connects different tables
+    # (Ignore None entries for unqualified columns)
+    left_named = {t for t in left_tables if t is not None}
+    right_named = {t for t in right_tables if t is not None}
+    if not left_named or not right_named:
+        return False
+    # Check if left and right reference different tables
+    return bool(left_named & right_named == set())  # No overlap = different tables
+
+
+def _has_join_condition_in_where(where: exp.Expression) -> bool:
+    """Check if WHERE clause contains a join condition (connecting multiple tables)."""
+    if not where:
+        return False
+    # Extract the actual condition from the WHERE wrapper (Where.this)
+    condition_expr = where.this if isinstance(where, exp.Where) else where
+    if not condition_expr:
+        return False
+    # Flatten AND conditions
+    return any(_is_join_condition(condition) for condition in _flatten_and(condition_expr))
+
+
+def _flatten_and(node: exp.Expression) -> list[exp.Expression]:
+    """Flatten a nested AND chain into a flat list of individual conditions."""
+    if isinstance(node, exp.And):
+        return _flatten_and(node.left) + _flatten_and(node.right)
+    return [node]
+
+
+class CrossJoinWithWhereConditionRule(LintOnlyRule):
+    """Lint: flag CROSS JOINs with WHERE clause connecting multiple tables.
+
+    A CROSS JOIN with a WHERE clause that connects columns from different tables
+    should be rewritten as an INNER JOIN with an ON clause.
+    """
+
+    def __init__(self, severity: str = "warn", overrides=None) -> None:
+        super().__init__(overrides=overrides)
+        self.severity = severity
+
+    @property
+    def name(self) -> str:
+        return "cross-join-with-where-condition"
+
+    def check(self, tree: exp.Expression) -> list[LintViolation]:
+        if self.severity == "off":
+            return []
+        violations: list[LintViolation] = []
+
+        for select in tree.find_all(exp.Select):
+            if not self.enabled_for_node(select):
+                continue
+
+            # Check if this SELECT has a CROSS JOIN
+            has_cross_join = False
+            for join in select.find_all(exp.Join):
+                # Check if it's a CROSS JOIN (explicit) or comma join (implicit)
+                is_cross = join.args.get("kind") == "CROSS" or (
+                    not join.args.get("kind")
+                    and not join.args.get("side")
+                    and not join.args.get("on")
+                    and not join.args.get("using")
+                )
+                if is_cross:
+                    has_cross_join = True
+                    break
+
+            if not has_cross_join:
+                continue
+
+            # Check if there's a WHERE clause with join conditions
+            where = select.args.get("where")
+            if _has_join_condition_in_where(where):
+                _line, _col = _node_pos(select)
+                violations.append(
+                    LintViolation(
+                        rule=self.name,
+                        severity=self.severity,
+                        message=(
+                            "CROSS JOIN with WHERE clause connecting multiple tables; "
+                            "rewrite as INNER JOIN with ON clause"
+                        ),
+                        line=_line,
+                        column=_col,
+                    )
+                )
+
+        return violations

--- a/tests/fixtures/joins/cross_join_with_where.expected.sql
+++ b/tests/fixtures/joins/cross_join_with_where.expected.sql
@@ -1,0 +1,24 @@
+SELECT
+   a.x
+  ,b.y
+FROM a
+CROSS JOIN b
+WHERE a.id = b.id
+;
+
+SELECT
+   x
+FROM t1
+CROSS JOIN t2
+CROSS JOIN t3
+WHERE t1.id = t2.id
+  AND t2.id = t3.id
+;
+
+SELECT
+   a
+  ,b
+FROM t1
+CROSS JOIN t2
+WHERE t1.id = t2.id
+;

--- a/tests/fixtures/joins/cross_join_with_where.input.sql
+++ b/tests/fixtures/joins/cross_join_with_where.input.sql
@@ -1,0 +1,3 @@
+SELECT a.x, b.y FROM a CROSS JOIN b WHERE a.id = b.id;
+SELECT x FROM t1 CROSS JOIN t2 CROSS JOIN t3 WHERE t1.id = t2.id AND t2.id = t3.id;
+SELECT a, b FROM t1, t2 WHERE t1.id = t2.id;

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -13,12 +13,12 @@ def _lint(sql: str, **config_overrides) -> list[str]:
 
 
 class TestCrossJoinWithWhereCondition:
-    def test_warns_on_cross_join_with_where_condition(self):
+    def test_errors_on_cross_join_with_where_condition(self):
         sql = "SELECT a.x FROM a CROSS JOIN b WHERE a.id = b.id"
         rules = _lint(sql)
         assert "cross-join-with-where-condition" in rules
 
-    def test_warns_on_comma_join_with_where_condition(self):
+    def test_errors_on_comma_join_with_where_condition(self):
         sql = "SELECT a.x FROM a, b WHERE a.id = b.id"
         rules = _lint(sql)
         assert "cross-join-with-where-condition" in rules

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -12,6 +12,39 @@ def _lint(sql: str, **config_overrides) -> list[str]:
     return [v.rule for v in lint_sql(sql, config)]
 
 
+class TestCrossJoinWithWhereCondition:
+    def test_warns_on_cross_join_with_where_condition(self):
+        sql = "SELECT a.x FROM a CROSS JOIN b WHERE a.id = b.id"
+        rules = _lint(sql)
+        assert "cross-join-with-where-condition" in rules
+
+    def test_warns_on_comma_join_with_where_condition(self):
+        sql = "SELECT a.x FROM a, b WHERE a.id = b.id"
+        rules = _lint(sql)
+        assert "cross-join-with-where-condition" in rules
+
+    def test_no_warn_on_cross_join_with_local_where(self):
+        # WHERE filters only one table
+        sql = "SELECT a.x FROM a CROSS JOIN b WHERE a.id > 10"
+        rules = _lint(sql)
+        assert "cross-join-with-where-condition" not in rules
+
+    def test_no_warn_on_cross_join_without_where(self):
+        sql = "SELECT a.x FROM a CROSS JOIN b"
+        rules = _lint(sql)
+        assert "cross-join-with-where-condition" not in rules
+
+    def test_no_warn_on_inner_join(self):
+        sql = "SELECT a.x FROM a INNER JOIN b ON a.id = b.id"
+        rules = _lint(sql)
+        assert "cross-join-with-where-condition" not in rules
+
+    def test_off_disables_rule(self):
+        sql = "SELECT a.x FROM a CROSS JOIN b WHERE a.id = b.id"
+        rules = _lint(sql, cross_join_with_where_condition="off")
+        assert "cross-join-with-where-condition" not in rules
+
+
 class TestNoImplicitCrossJoin:
     def test_warns_on_comma_join(self):
         rules = _lint("SELECT a FROM t1, t2")


### PR DESCRIPTION
# Summary

Adds a new lint rule to flag CROSS JOINs with WHERE clauses that connect columns from multiple tables (issue #305). A CROSS JOIN with `WHERE a.id = b.id` is logically equivalent to an INNER JOIN and should be written as one.

## Bad patterns (flagged as ERROR)

```sql
SELECT a.x, b.y FROM a CROSS JOIN b WHERE a.id = b.id;
```

```sql
SELECT x FROM t1, t2 WHERE t1.id = t2.id;
```

## Good patterns (not flagged)

```sql
SELECT a.x, b.y FROM a INNER JOIN b ON a.id = b.id;
```

```sql
-- CROSS JOIN with no WHERE, or WHERE that filters only one table, is fine
SELECT a.x, b.y FROM a CROSS JOIN b WHERE a.active = true;
```

## Changes

- `src/jarify/rules/cross_join_with_where_condition.py` — new rule
- `src/jarify/rules/__init__.py` — registered in catalog (default: error)
- `src/jarify/config.py` — config key `cross_join_with_where_condition`
- `tests/test_lint_rules.py` — 6 unit tests
- `tests/fixtures/joins/cross_join_with_where.{input,expected}.sql` — fixtures
- `docs/rules.md` — regenerated

All 314 tests pass.

Resolves #305