### PR TITLE
deps: unpin `uv`

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,5 @@
 [tools]
-# uv pinned: 0.11.9 was published manually (crates.io timeout) and explicitly
-# lacks GitHub attestations. check-uv-pin.yml polls weekly and will auto-PR to
-# restore "latest" once attestations pass. See: amfaro/calc#3232
-uv = "0.11.8"
+uv = "latest"
 git-cliff = "latest"
 
 [env]


### PR DESCRIPTION
There is a new version that no longer triggers the attestation errors with `mise`.

Resolves #313
