### PR TITLE
feat(overrides): support `all` wildcard in disable directives

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -64,6 +64,11 @@ The `disable-next-line` directive disables a rule for the *entire next SQL
 statement*, not just the next literal line. Multi-line statements are fully
 covered by a single directive placed before the statement.
 
+Use `all` in place of a rule name to match every rule (e.g.
+`-- jarify: disable-file all`). `enable all` closes every open `disable`
+region. See [`sql-style-guide.md`](sql-style-guide.md#comment-overrides) for
+the full directive reference.
+
 Run `jarify rules` to print this table in your terminal, or
 `jarify rules --format json` for a machine-readable list suitable for
 editor integrations (e.g. LSP completion for disable directives).

--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -1077,12 +1077,18 @@ Supported directives:
 - `-- jarify: disable-file <rule>` — disable a rule for the whole file
 - `-- jarify: set max_line_length = 140` / `-- jarify: reset max_line_length` — override line length for following statements until reset
 
-Rules use their lint names such as `no-select-star`, `cte-naming`, or `prefer-if-over-case`.
+Rules use their lint names such as `no-select-star`, `cte-naming`, or `prefer-if-over-case`. The wildcard `all` matches every rule — handy for silencing files edited in a non-DuckDB IDE. `enable all` closes every open `disable` region.
 
 **Example**
 ```sql
 -- jarify: disable-next-line prefer-if-over-case
 SELECT CASE WHEN is_large THEN 'big' ELSE 'small' END FROM sizes
+```
+
+**Disable everything for a file**
+```sql
+-- jarify: disable-file all
+SELECT * FROM scratchpad
 ```
 
 **Good output**

--- a/scripts/gen_rules_doc.py
+++ b/scripts/gen_rules_doc.py
@@ -69,6 +69,11 @@ The `disable-next-line` directive disables a rule for the *entire next SQL
 statement*, not just the next literal line. Multi-line statements are fully
 covered by a single directive placed before the statement.
 
+Use `all` in place of a rule name to match every rule (e.g.
+`-- jarify: disable-file all`). `enable all` closes every open `disable`
+region. See [`sql-style-guide.md`](sql-style-guide.md#comment-overrides) for
+the full directive reference.
+
 Run `jarify rules` to print this table in your terminal, or
 `jarify rules --format json` for a machine-readable list suitable for
 editor integrations (e.g. LSP completion for disable directives).

--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -232,6 +232,10 @@ def rules_cmd(output_format: str) -> None:
     for r in RULE_CATALOG:
         fix = "yes" if r.auto_fix else "no"
         console.print(f"{r.name:<{name_w}} {r.default:<{sev_w}} {fix:<{fix_w}} {r.description}")
+    console.print(
+        "\n[dim]Use `all` in disable directives to match every rule "
+        "(e.g. `-- jarify: disable-file all`).[/dim]"
+    )
 
 
 @main.command("init")

--- a/src/jarify/comment_overrides.py
+++ b/src/jarify/comment_overrides.py
@@ -26,6 +26,8 @@ RULE_ALIASES: dict[str, str] = {
     "prefer-if-over-case": "prefer-if-over-case",
     "prefer-ifnull-over-coalesce": "prefer-ifnull-over-coalesce",
     "parse-error": "parse-error",
+    # `all` is a wildcard handled directly in is_rule_disabled() and the
+    # `enable` directive — there is no rule named "all".
     "all": "all",
 }
 
@@ -157,7 +159,13 @@ def parse_comment_overrides(sql: str) -> CommentOverrides:
             continue
 
         if directive.kind == "enable":
-            for rule in _parse_rules(directive.args):
+            rules = _parse_rules(directive.args)
+            if "all" in rules:
+                for open_rule, start in open_rule_ranges.items():
+                    rule_ranges.append(_RuleRange(start, line_no - 1, open_rule))
+                open_rule_ranges.clear()
+                continue
+            for rule in rules:
                 if rule in open_rule_ranges:
                     rule_ranges.append(_RuleRange(open_rule_ranges.pop(rule), line_no - 1, rule))
             continue

--- a/tests/test_comment_overrides.py
+++ b/tests/test_comment_overrides.py
@@ -69,6 +69,77 @@ class TestLintOverrides:
         sql = "-- jarify: disable no-select-star\nSELECT * FROM t;\n-- jarify: enable no-select-star\nSELECT * FROM u\n"
         assert _lint(sql, prefer_from_first=False) == ["no-select-star"]
 
+    def test_disable_line_all_suppresses_every_rule(self):
+        sql = "SELECT coalesce(a, b) FROM T -- jarify: disable-line all"
+        assert _lint(sql, prefer_from_first=False) == []
+
+    def test_disable_next_line_all_suppresses_every_rule(self):
+        sql = "-- jarify: disable-next-line all\nSELECT coalesce(a, b) FROM T\n;\n"
+        assert _lint(sql, prefer_from_first=False) == []
+
+    def test_disable_file_all_suppresses_every_rule(self):
+        sql = (
+            "-- jarify: disable-file all\n"
+            "SELECT * FROM t;\n"
+            "SELECT coalesce(a, b) FROM u;\n"
+        )
+        assert _lint(sql, prefer_from_first=False) == []
+
+    def test_disable_all_region_suppresses_every_rule(self):
+        sql = (
+            "-- jarify: disable all\n"
+            "SELECT * FROM t;\n"
+            "SELECT coalesce(a, b) FROM u;\n"
+            "-- jarify: enable all\n"
+            "SELECT * FROM v\n"
+        )
+        assert _lint(sql, prefer_from_first=False) == ["no-select-star"]
+
+    def test_enable_all_closes_specific_open_disables(self):
+        # `disable some-rule` followed by `enable all` should close the open
+        # range, so violations after `enable all` are reported normally.
+        sql = (
+            "-- jarify: disable no-select-star\n"
+            "SELECT * FROM t;\n"
+            "-- jarify: enable all\n"
+            "SELECT * FROM u\n"
+        )
+        assert _lint(sql, prefer_from_first=False) == ["no-select-star"]
+
+    def test_disable_line_all_is_case_insensitive(self):
+        sql = "SELECT coalesce(a, b) FROM T -- jarify: disable-line ALL"
+        assert _lint(sql, prefer_from_first=False) == []
+
+    def test_enable_specific_rule_inside_disable_all_is_noop(self):
+        # Pin current behavior: `disable all` is range-keyed by "all", so
+        # `enable some-rule` does not split the range. Document this rather
+        # than silently change it.
+        sql = (
+            "-- jarify: disable all\n"
+            "SELECT * FROM t;\n"
+            "-- jarify: enable no-select-star\n"
+            "SELECT * FROM u\n"
+        )
+        assert _lint(sql, prefer_from_first=False) == []
+
+
+class TestFormatOverridesAll:
+    def test_disable_next_line_all_preserves_multiple_rewrites(self):
+        # Format-side coverage for `all`: a single statement that would trigger
+        # several formatter rewrites must be left alone end-to-end.
+        sql = (
+            "-- jarify: disable-next-line all\n"
+            "SELECT CASE WHEN a > 1 THEN 'big' ELSE 'small' END, coalesce(x, y) FROM t1, t2\n"
+        )
+
+        formatted, _ = format_sql(sql)
+
+        assert "CASE" in formatted
+        assert "if(" not in formatted
+        assert "coalesce(x, y)" in formatted
+        assert "ifnull(x, y)" not in formatted
+        assert "CROSS JOIN" not in formatted
+
 
 class TestFormatOverrides:
     def test_disable_next_line_preserves_case_expression(self):


### PR DESCRIPTION
Closes #316.

## What

Make `all` a valid wildcard rule name in jarify comment-override directives, matching every registered rule:

- `-- jarify: disable-line all`
- `-- jarify: disable-next-line all`
- `-- jarify: disable-file all`
- `-- jarify: disable all` … `-- jarify: enable all`

This is the use case the issue called out: silencing jarify on a file (or line) being edited in a tool that mangles SQL — e.g. a non-DuckDB IDE like DataGrip.

## Why this is more than docs

The simple cases were already accepted by `is_rule_disabled()` (which already special-cased the literal string `"all"`), but were undocumented, untested, and had a real bug at the boundaries:

- `-- jarify: disable some-rule` … `-- jarify: enable all` previously left the open range dangling to EOF — `enable` only popped the rule it was keyed by, and `enable all` was keyed on `"all"`. This PR makes `enable all` close every currently-open `disable` region.

## Out of scope

Splitting an `"all"` range when it's followed by `-- jarify: enable specific-rule` would require tracking individual rules in disabled regions and is meaningfully larger. The current behavior (silent no-op — `disable all` continues to suppress everything until matching `enable all` or EOF) is now pinned by a regression test (`test_enable_specific_rule_inside_disable_all_is_noop`). Easy to lift later if a user asks.

## Changes

- `src/jarify/comment_overrides.py` — `enable` directive closes every open range when given `all`; explanatory comment near the `RULE_ALIASES["all"]` entry.
- `tests/test_comment_overrides.py` — eight new tests across linter and formatter paths covering all four directive shapes, case-insensitivity, the asymmetric-close bug fix, and the deferred case.
- `docs/sql-style-guide.md` — Comment overrides section now mentions `all` with a "disable everything for a file" example.
- `scripts/gen_rules_doc.py` + `docs/rules.md` (regenerated) — Disable-directives footer mentions `all`.
- `src/jarify/cli.py` — `jarify rules` text output ends with a one-line note about the `all` wildcard. JSON output is unchanged so existing LSP integrations are unaffected.

## Validation

- `mise run check` (lint + 330 tests, was 327) — pass
- `mise run check-rules-doc` — passes after commit (only failed locally due to uncommitted regenerated state)
