### PR TITLE
fix(formatter): preserve MATERIALIZED keyword on CTEs

### DIFF
--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -532,7 +532,16 @@ class JarifyGenerator(DuckDB.Generator):
             if text:
                 trail_parts.append(f"/*{c}*/" if "\n" in c else f"-- {text}")
         comment_suffix = (" " + " ".join(trail_parts)) if trail_parts else ""
-        body = f"{alias_sql} AS{comment_suffix}\n{self.wrap(expression)}"
+
+        materialized = expression.args.get("materialized")
+        if materialized is True:
+            materialized_str = " MATERIALIZED"
+        elif materialized is False:
+            materialized_str = " NOT MATERIALIZED"
+        else:
+            materialized_str = ""
+
+        body = f"{alias_sql} AS{materialized_str}{comment_suffix}\n{self.wrap(expression)}"
 
         if lead:
             prefix = "\n".join(f"-- {c.strip()}" for c in lead if c.strip())

--- a/tests/fixtures/cte/materialized_cte.expected.sql
+++ b/tests/fixtures/cte/materialized_cte.expected.sql
@@ -1,0 +1,18 @@
+WITH RECURSIVE _transactions AS MATERIALIZED
+(
+  FROM t
+)
+,_hint_off AS NOT MATERIALIZED
+(
+  FROM u
+)
+,_plain AS
+(
+  FROM v
+)
+SELECT
+   *
+FROM _transactions
+INNER JOIN _hint_off USING (id)
+INNER JOIN _plain USING (id)
+;

--- a/tests/fixtures/cte/materialized_cte.input.sql
+++ b/tests/fixtures/cte/materialized_cte.input.sql
@@ -1,0 +1,4 @@
+with recursive _transactions as materialized (select * from t),
+     _hint_off as not materialized (select * from u),
+     _plain as (select * from v)
+select * from _transactions join _hint_off using (id) join _plain using (id)

--- a/tests/fixtures/cte/materialized_cte_leading_comment.expected.sql
+++ b/tests/fixtures/cte/materialized_cte_leading_comment.expected.sql
@@ -1,0 +1,12 @@
+WITH _base AS
+(
+  SELECT
+     1
+)
+-- materialize for reuse below
+,_hot AS MATERIALIZED
+(
+  FROM _base
+)
+FROM _hot
+;

--- a/tests/fixtures/cte/materialized_cte_leading_comment.input.sql
+++ b/tests/fixtures/cte/materialized_cte_leading_comment.input.sql
@@ -1,0 +1,4 @@
+WITH _base AS (SELECT 1)
+-- materialize for reuse below
+,_hot AS MATERIALIZED (SELECT * FROM _base)
+SELECT * FROM _hot;


### PR DESCRIPTION
> [!NOTE]
> This issue was authored by Claude Code (Claude claude-sonnet-4-56) on behalf of @johnallen3d.

Fixes #315.

## Problem
`JarifyGenerator.cte_sql` overrides sqlglot's base method but never reads the `materialized` arg on `exp.CTE`. sqlglot parses `MATERIALIZED` and `NOT MATERIALIZED` correctly into a tri-state boolean, but jarify's renderer ignored it, silently stripping the hint when reformatting.

Reported case: a recursive CTE
```sql
WITH RECURSIVE _transactions AS MATERIALIZED ( ... )
```
was reformatted as
```sql
WITH RECURSIVE _transactions AS ( ... )
```

## Fix
Read `expression.args.get("materialized")` in `cte_sql` and emit ` MATERIALIZED` or ` NOT MATERIALIZED` between `AS` and the wrapped body. Tri-state: `True` / `False` / `None`.

## Tests
- `tests/fixtures/cte/materialized_cte` — recursive CTE with `MATERIALIZED`, `NOT MATERIALIZED`, and a plain CTE in one query.
- `tests/fixtures/cte/materialized_cte_leading_comment` — `MATERIALIZED` alongside the `lead`-comment hoisting path.

Both cases also exercise `test_format_idempotent`. Full suite: 332 passing.