### PR TITLE
feat(config): support user-global config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Reads each file, formats it, and writes the result back in place.
 | Option | Description |
 |--------|-------------|
 | `-` | Read from stdin |
+| `--config PATH` | Load config from an explicit file path |
 | `--check` | Exit non-zero if any file would change (useful in CI) |
 | `--diff` | Print a unified diff instead of rewriting files |
-| `--stdin-filename NAME` | Label to use in diff output when reading from stdin |
+| `--stdin-filename NAME` | Config discovery anchor and diff label when reading from stdin |
 
 **Exit codes:** `0` = all files already formatted, `1` = files were reformatted, `2` = error.
 
@@ -69,6 +70,12 @@ jarify lint [OPTIONS] [FILES]...
 
 Reports style and semantic violations. Does not modify files.
 
+| Option | Description |
+|--------|-------------|
+| `--config PATH` | Load config from an explicit file path |
+| `--stdin-filename NAME` | Config discovery anchor and filename label when reading from stdin |
+| `--format text|json` | Output format |
+
 ```bash
 jarify lint query.sql
 ```
@@ -79,19 +86,52 @@ jarify lint query.sql
 jarify init
 ```
 
-Writes a `jarify.toml` in the current directory. Config is internal to the tool — this is primarily useful for future per-project rule overrides.
+Writes a project-local `jarify.toml` in the current directory.
 
 ### `jarify show-config` — inspect active config
 
 ```bash
 jarify show-config
+jarify show-config --config path/to/jarify.toml
 ```
 
 Prints the effective configuration (syntax-highlighted TOML).
 
+## Configuration files
+
+When `--config PATH` is provided, that file wins and no discovery runs. Without `--config`, Jarify looks for config in this order:
+
+1. Project-local `jarify.toml`, found by walking upward from the config start directory.
+   - For stdin, `--stdin-filename` sets the start directory.
+   - Otherwise, discovery starts from the current working directory.
+2. The first existing global config:
+   1. `$XDG_CONFIG_HOME/jarify/config.toml`
+   2. `$XDG_CONFIG_HOME/jarify/jarify.toml`
+   3. `~/.config/jarify/config.toml`
+   4. `~/.config/jarify/jarify.toml`
+   5. `~/jarify.toml`
+3. Built-in defaults
+
+When both project-local and global config exist, Jarify loads the global config first and overlays the project-local config on top. This lets global config hold personal defaults while project config still enforces repository policy. Explicit `--config PATH` is not merged with any other config.
+
+Project-local config is best for repository style rules that should be shared by every contributor:
+
+```toml
+[jarify]
+no_select_star = "error"
+```
+
+Global config is useful for personal preferences that should not be committed to a repo:
+
+```toml
+# ~/.config/jarify/config.toml
+[jarify]
+indent = 4
+```
+
 ## Style and lint rules
 
-Jarify enforces a single, opinionated style. There are no knobs to turn. See the **[SQL Style Guide](docs/sql-style-guide.md)** for the complete rule reference with bad/good examples for every formatting and lint rule.
+Jarify enforces a single, opinionated default style with limited config for rule severity and personal preferences. See the **[SQL Style Guide](docs/sql-style-guide.md)** for the complete rule reference with bad/good examples for every formatting and lint rule.
 
 ## Development
 

--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -56,7 +56,7 @@ def main() -> None:
 @click.option("--config", "config_path", type=click.Path(exists=True, path_type=Path), default=None)
 @click.option("--check", is_flag=True, help="Exit non-zero if any file would change; don't write.")
 @click.option("--diff", is_flag=True, help="Print a unified diff of changes instead of writing.")
-@click.option("--stdin-filename", default="<stdin>", help="Filename label when reading from stdin.")
+@click.option("--stdin-filename", default="<stdin>", help="Config discovery anchor and filename label for stdin.")
 def fmt(
     files: tuple[Path, ...],
     config_path: Path | None,
@@ -118,7 +118,7 @@ def fmt(
 @main.command("lint")
 @click.argument("files", nargs=-1, type=click.Path(path_type=Path))
 @click.option("--config", "config_path", type=click.Path(exists=True, path_type=Path), default=None)
-@click.option("--stdin-filename", default="<stdin>", help="Filename label when reading from stdin.")
+@click.option("--stdin-filename", default="<stdin>", help="Config discovery anchor and filename label for stdin.")
 @click.option(
     "--format",
     "output_format",

--- a/src/jarify/config.py
+++ b/src/jarify/config.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import copy
+import os
 import tomllib
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 DEFAULT_CONFIG_NAME = "jarify.toml"
+GLOBAL_CONFIG_NAMES = ("config.toml", DEFAULT_CONFIG_NAME)
 
 
 @dataclass
@@ -61,10 +65,11 @@ class JarifyConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> JarifyConfig:
-        rules = data.pop("rules", {})
+        config_data = dict(data)
+        rules = config_data.pop("rules", {})
         # Flatten any per-rule severity shortcuts from [rules.no_select_star] etc.
         known_fields = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
-        filtered = {k.replace("-", "_"): v for k, v in data.items() if k.replace("-", "_") in known_fields}
+        filtered = {k.replace("-", "_"): v for k, v in config_data.items() if k.replace("-", "_") in known_fields}
         return cls(**filtered, rules=rules)
 
 
@@ -78,17 +83,67 @@ def find_config(start: Path | None = None) -> Path | None:
     return None
 
 
+def iter_global_config_paths() -> Iterator[Path]:
+    """Yield global config candidates in precedence order."""
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        xdg_jarify_dir = Path(xdg_config_home).expanduser() / "jarify"
+        for name in GLOBAL_CONFIG_NAMES:
+            yield xdg_jarify_dir / name
+
+    default_jarify_dir = Path.home() / ".config" / "jarify"
+    for name in GLOBAL_CONFIG_NAMES:
+        yield default_jarify_dir / name
+
+    yield Path.home() / DEFAULT_CONFIG_NAME
+
+
+def find_global_config() -> Path | None:
+    """Return the first existing user-global config file, if any."""
+    for candidate in iter_global_config_paths():
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_config_data(path: Path) -> dict[str, Any]:
+    """Load raw config data from *path*."""
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return copy.deepcopy(data.get("jarify", data))
+
+
+def _merge_config_data(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge config data, with *overlay* values taking precedence."""
+    merged = copy.deepcopy(base)
+    for key, value in overlay.items():
+        base_value = merged.get(key)
+        if isinstance(base_value, dict) and isinstance(value, dict):
+            merged[key] = _merge_config_data(base_value, value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
 def load_config(path: Path | None = None, start: Path | None = None) -> JarifyConfig:
     """Load config from a file path, or discover one automatically.
 
     *start* seeds the upward search when no explicit *path* is given.
     Pass the parent directory of the file being processed (e.g. from
     ``--stdin-filename``) so config discovery anchors to that file rather
-    than ``cwd``.
+    than ``cwd``. Discovered project config is overlaid onto the first
+    discovered global config.
     """
-    config_path = path or find_config(start)
-    if config_path is None:
-        return JarifyConfig()
-    with config_path.open("rb") as f:
-        data = tomllib.load(f)
-    return JarifyConfig.from_dict(data.get("jarify", data))
+    if path is not None:
+        return JarifyConfig.from_dict(_load_config_data(path))
+
+    project_config_path = find_config(start)
+    global_config_path = find_global_config()
+    if project_config_path is not None and global_config_path is not None:
+        data = _merge_config_data(_load_config_data(global_config_path), _load_config_data(project_config_path))
+        return JarifyConfig.from_dict(data)
+    if project_config_path is not None:
+        return JarifyConfig.from_dict(_load_config_data(project_config_path))
+    if global_config_path is not None:
+        return JarifyConfig.from_dict(_load_config_data(global_config_path))
+    return JarifyConfig()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """pytest configuration and shared fixtures."""
 
+from pathlib import Path
+
 import pytest
 
 
@@ -10,6 +12,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Regenerate all .expected.sql snapshot files.",
     )
+
+
+@pytest.fixture(autouse=True)
+def isolated_global_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep developer-machine global Jarify config out of tests."""
+    home = tmp_path / "home"
+    xdg_config_home = tmp_path / "xdg-config"
+    home.mkdir()
+    xdg_config_home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_home))
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from jarify.cli import main
@@ -52,3 +53,19 @@ def test_fmt_file_reports_unchanged_when_input_is_file(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "unchanged" in result.output
     assert str(sql_file) in result.output.replace("\n", "")
+
+
+def test_show_config_uses_global_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    global_config = home / ".config" / "jarify" / "config.toml"
+    global_config.parent.mkdir(parents=True)
+    global_config.write_text("[jarify]\nindent = 6\n")
+
+    with CliRunner().isolated_filesystem(temp_dir=tmp_path):
+        result = CliRunner().invoke(main, ["show-config"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "indent" in result.output
+    assert "= 6" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 import pytest
 
-from jarify.config import JarifyConfig, find_config, load_config
+from jarify.config import (
+    JarifyConfig,
+    _merge_config_data,
+    find_config,
+    find_global_config,
+    iter_global_config_paths,
+    load_config,
+)
 
 
 def test_default_config():
@@ -59,6 +66,130 @@ def test_load_config_explicit_path_takes_precedence(tmp_path: Path) -> None:
     assert config.indent == 3
 
 
+def test_global_config_paths_follow_precedence_order(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    xdg_config_home = tmp_path / "xdg"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_home))
+
+    assert list(iter_global_config_paths()) == [
+        xdg_config_home / "jarify" / "config.toml",
+        xdg_config_home / "jarify" / "jarify.toml",
+        home / ".config" / "jarify" / "config.toml",
+        home / ".config" / "jarify" / "jarify.toml",
+        home / "jarify.toml",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("global_path", "indent"),
+    [
+        (("xdg", "jarify", "config.toml"), 3),
+        (("xdg", "jarify", "jarify.toml"), 4),
+        (("home", ".config", "jarify", "config.toml"), 5),
+        (("home", ".config", "jarify", "jarify.toml"), 6),
+        (("home", "jarify.toml"), 7),
+    ],
+)
+def test_load_config_uses_each_global_config_location(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    global_path: tuple[str, ...],
+    indent: int,
+) -> None:
+    home = tmp_path / "home"
+    xdg_config_home = tmp_path / "xdg"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_home))
+    root = xdg_config_home if global_path[0] == "xdg" else home
+    global_config = root.joinpath(*global_path[1:])
+    global_config.parent.mkdir(parents=True, exist_ok=True)
+    global_config.write_text(f"[jarify]\nindent = {indent}\n")
+
+    assert find_global_config() == global_config
+    assert load_config(start=tmp_path).indent == indent
+
+
+def test_find_global_config_uses_earliest_candidate_when_multiple_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    xdg_config_home = tmp_path / "xdg"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_home))
+
+    candidates = list(iter_global_config_paths())
+    for index, candidate in enumerate(candidates, start=3):
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_text(f"[jarify]\nindent = {index}\n")
+
+    assert find_global_config() == candidates[0]
+    assert load_config(start=tmp_path).indent == 3
+
+
+def test_load_config_merges_project_config_over_global_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    global_config = home / ".config" / "jarify" / "config.toml"
+    global_config.parent.mkdir(parents=True)
+    global_config.write_text("[jarify]\nindent = 6\nmax_line_length = 100\n")
+    project_config = tmp_path / "project" / "jarify.toml"
+    project_config.parent.mkdir()
+    project_config.write_text("[jarify]\nindent = 3\n")
+
+    config = load_config(start=project_config.parent)
+
+    assert config.indent == 3
+    assert config.max_line_length == 100
+
+
+def test_load_config_merges_nested_rules_from_project_and_global_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    global_config = home / ".config" / "jarify" / "config.toml"
+    global_config.parent.mkdir(parents=True)
+    global_config.write_text('[jarify.rules.no_select_star]\nseverity = "error"\n')
+    project_config = tmp_path / "project" / "jarify.toml"
+    project_config.parent.mkdir()
+    project_config.write_text('[jarify.rules.no_unused_cte]\nseverity = "off"\n')
+
+    config = load_config(start=project_config.parent)
+
+    assert config.rules == {
+        "no_select_star": {"severity": "error"},
+        "no_unused_cte": {"severity": "off"},
+    }
+
+
+def test_load_config_explicit_path_takes_precedence_over_project_and_global(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    global_config = home / ".config" / "jarify" / "config.toml"
+    global_config.parent.mkdir(parents=True)
+    global_config.write_text("[jarify]\nindent = 6\n")
+    project_config = tmp_path / "project" / "jarify.toml"
+    project_config.parent.mkdir()
+    project_config.write_text("[jarify]\nindent = 3\n")
+    explicit = tmp_path / "explicit.toml"
+    explicit.write_text("[jarify]\nindent = 9\n")
+
+    config = load_config(path=explicit, start=project_config.parent)
+
+    assert config.indent == 9
+
+
+def test_load_config_uses_defaults_when_no_config_exists(tmp_path: Path) -> None:
+    config = load_config(start=tmp_path)
+
+    assert config.indent == JarifyConfig().indent
+
+
 def test_config_from_dict_kebab_keys():
     """Kebab-case keys in jarify.toml are accepted and normalized."""
     config = JarifyConfig.from_dict(
@@ -78,6 +209,26 @@ def test_config_from_dict_mixed_case_keys():
     config = JarifyConfig.from_dict({"indent": 4, "no-unused-cte": "error"})
     assert config.indent == 4
     assert config.no_unused_cte == "error"
+
+
+def test_config_from_dict_does_not_mutate_input() -> None:
+    data = {"indent": 4, "rules": {"no_select_star": {"severity": "error"}}}
+
+    JarifyConfig.from_dict(data)
+
+    assert data == {"indent": 4, "rules": {"no_select_star": {"severity": "error"}}}
+
+
+def test_merge_config_data_does_not_alias_inputs() -> None:
+    base = {"rules": {"no_select_star": {"severity": "warn"}}}
+    overlay = {"rules": {"no_unused_cte": {"severity": "off"}}}
+
+    merged = _merge_config_data(base, overlay)
+    merged["rules"]["no_select_star"]["severity"] = "error"
+    merged["rules"]["no_unused_cte"]["severity"] = "warn"
+
+    assert base == {"rules": {"no_select_star": {"severity": "warn"}}}
+    assert overlay == {"rules": {"no_unused_cte": {"severity": "off"}}}
 
 
 @pytest.mark.parametrize("command", ["fmt", "lint"])


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by GitHub Copilot (gpt-5.5) on behalf of @johnallen3d.

## Summary

Adds user-global Jarify config discovery for personal preferences that should not live in a project repository.

The discovery model keeps explicit `--config` as an exact-file override. Without `--config`, Jarify loads the first discovered global config and overlays project-local `jarify.toml` when present, so repo policy can override personal defaults.

Resolves #322
