### PR TITLE
feat(formatter): add min column alias

### DIFF
--- a/docs/sql-style-guide.md
+++ b/docs/sql-style-guide.md
@@ -560,6 +560,15 @@ CROSS JOIN UNNEST(o.vals) t(v)
 
 When a query contains two or more column aliases anywhere in its query-wide `SELECT` lists, the `AS` keyword is aligned to one visible column across the full query. That includes the outer query plus CTE bodies, including nested CTEs, even when those `SELECT` lists are indented at different depths. Multi-line expressions still participate — the closing line (for example `END`) is padded so its trailing `AS` lines up with neighboring single-line aliases.
 
+You can also set a minimum visible alias column with `min-column-alias`. Jarify then uses the greater of the configured minimum and the naturally computed alignment column. Longer expressions still win; the setting is a floor, not a fixed hard stop.
+
+Project config example:
+
+```toml
+[jarify]
+min-column-alias = 24
+```
+
 **Bad**
 ```sql
 SELECT a AS foo, some_long_expression AS bar FROM t
@@ -639,6 +648,15 @@ SELECT
   ,sibling_two         AS final_two
 FROM _outer_group
 INNER JOIN _sibling_group ON outer_one = sibling_one
+;
+```
+
+**Also good** (`min-column-alias = 24`)
+```sql
+SELECT
+   a                    AS one
+  ,bb                   AS two
+FROM t
 ;
 ```
 
@@ -1076,6 +1094,7 @@ Supported directives:
 - `-- jarify: disable <rule>` / `-- jarify: enable <rule>` — disable a rule for a region
 - `-- jarify: disable-file <rule>` — disable a rule for the whole file
 - `-- jarify: set max_line_length = 140` / `-- jarify: reset max_line_length` — override line length for following statements until reset
+- `-- jarify: set min-column-alias = 80` / `-- jarify: reset min-column-alias` — set or clear a minimum visible column-alias alignment floor for following statements
 
 Rules use their lint names such as `no-select-star`, `cte-naming`, or `prefer-if-over-case`. The wildcard `all` matches every rule — handy for silencing files edited in a non-DuckDB IDE. `enable all` closes every open `disable` region.
 
@@ -1083,6 +1102,15 @@ Rules use their lint names such as `no-select-star`, `cte-naming`, or `prefer-if
 ```sql
 -- jarify: disable-next-line prefer-if-over-case
 SELECT CASE WHEN is_large THEN 'big' ELSE 'small' END FROM sizes
+```
+
+**File-specific alias floor**
+```sql
+-- jarify: set min-column-alias = 80
+SELECT short_col AS short_alias, other_col AS other_alias FROM t
+;
+
+-- jarify: reset min-column-alias
 ```
 
 **Disable everything for a file**

--- a/src/jarify/cli.py
+++ b/src/jarify/cli.py
@@ -28,6 +28,10 @@ dialect         = "duckdb"
 indent          = 2
 max_line_length = 120
 
+# Minimum visible column for SELECT alias alignment.
+# Longer expressions still push aliases farther right.
+# min_column_alias = 80
+
 # Comma placement: set trailing_commas = false and leading_commas = true
 # to use leading commas (SQL Server / dbt style)
 trailing_commas = true
@@ -264,7 +268,7 @@ def show_config(config_path: Path | None) -> None:
             lines.append(f"{f.name:<22} = {'true' if val else 'false'}")
         elif isinstance(val, str):
             lines.append(f'{f.name:<22} = "{val}"')
-        else:
+        elif val is not None:
             lines.append(f"{f.name:<22} = {val}")
     toml_text = "\n".join(lines) + "\n"
     console.print(Syntax(toml_text, "toml", theme="monokai"))

--- a/src/jarify/comment_overrides.py
+++ b/src/jarify/comment_overrides.py
@@ -35,6 +35,8 @@ SETTING_ALIASES: dict[str, str] = {
     "max-line-length": "max_line_length",
     "line-length": "max_line_length",
     "max_line_length": "max_line_length",
+    "min-column-alias": "min_column_alias",
+    "min_column_alias": "min_column_alias",
 }
 
 _DIRECTIVE_RE = re.compile(r"jarify:\s*(.+)", re.IGNORECASE)
@@ -217,6 +219,12 @@ def _parse_setting(args: str) -> tuple[str | None, Any]:
         return None, None
     raw_name, raw_value = [part.strip() for part in args.split("=", 1)]
     name = normalize_setting_name(raw_name)
-    if name == "max_line_length":
-        return name, int(raw_value)
+    if name in {"max_line_length", "min_column_alias"}:
+        try:
+            value = int(raw_value)
+        except ValueError:
+            return None, None
+        if name == "min_column_alias" and value <= 0:
+            return None, None
+        return name, value
     return name, raw_value

--- a/src/jarify/config.py
+++ b/src/jarify/config.py
@@ -22,6 +22,7 @@ class JarifyConfig:
     dialect: str = "duckdb"
     indent: int = 2
     max_line_length: int = 120
+    min_column_alias: int | None = None
 
     # --- keyword / identifier casing ---
     uppercase_keywords: bool = True
@@ -62,6 +63,10 @@ class JarifyConfig:
         # leading_commas takes precedence if explicitly set
         if self.leading_commas:
             self.trailing_commas = False
+
+        # Non-positive alias columns are treated as unset.
+        if self.min_column_alias is not None and self.min_column_alias <= 0:
+            self.min_column_alias = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> JarifyConfig:

--- a/src/jarify/generator.py
+++ b/src/jarify/generator.py
@@ -321,7 +321,7 @@ class JarifyGenerator(DuckDB.Generator):
             return "\n".join(parts)
         return " " + " ".join(parts)
 
-    def _compute_as_align_width(self, expressions_list: list) -> int | None:
+    def _compute_as_align_width(self, expressions_list: list, *, prefix_width: int = 0) -> int | None:
         """Compute the column width for AS alignment in a SELECT expression list.
 
         Returns None if alignment should not be applied (< 2 aliases total).
@@ -334,7 +334,11 @@ class JarifyGenerator(DuckDB.Generator):
         col_widths, alias_count = self._collect_as_alignment_metrics(expressions_list)
         if alias_count < 2:
             return None
-        return max(col_widths)
+        align_width = max(col_widths)
+        min_column_alias = self._config.min_column_alias
+        if min_column_alias is None:
+            return align_width
+        return max(align_width, max(0, min_column_alias - prefix_width))
 
     def _compute_tree_as_align_column(self, expression: exp.Expr) -> int | None:
         """Compute one visible AS column across the query-wide CTE/select tree."""
@@ -349,7 +353,11 @@ class JarifyGenerator(DuckDB.Generator):
         if alias_count < 2 or not as_columns:
             return None
 
-        return max(as_columns)
+        align_column = max(as_columns)
+        min_column_alias = self._config.min_column_alias
+        if min_column_alias is None:
+            return align_column
+        return max(align_column, min_column_alias)
 
     def _iter_query_aligned_selects(self, expression: exp.Expr) -> t.Iterator[exp.Select]:
         """Yield SELECTs that share query-wide alias alignment.
@@ -1204,7 +1212,7 @@ class JarifyGenerator(DuckDB.Generator):
             saved_align = self._as_align_width
             payload_expressions = list(expression.args.get(key) or [])
             if key in ("replace", "rename"):
-                self._as_align_width = self._compute_as_align_width(payload_expressions)
+                self._as_align_width = self._compute_as_align_width(payload_expressions, prefix_width=self.pad + 4)
             try:
                 payload = self.expressions(expression, key=key, indent=False)
             finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,3 +69,25 @@ def test_show_config_uses_global_config(tmp_path: Path, monkeypatch: pytest.Monk
     assert result.exit_code == 0
     assert "indent" in result.output
     assert "= 6" in result.output
+    assert "min_column_alias" not in result.output
+
+
+def test_show_config_includes_min_column_alias_when_set(tmp_path: Path) -> None:
+    config_file = tmp_path / "jarify.toml"
+    config_file.write_text("[jarify]\nmin-column-alias = 80\n")
+
+    with CliRunner().isolated_filesystem(temp_dir=tmp_path):
+        result = CliRunner().invoke(main, ["show-config", "--config", str(config_file)], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "min_column_alias" in result.output
+    assert "= 80" in result.output
+
+
+def test_init_mentions_min_column_alias(tmp_path: Path) -> None:
+    with CliRunner().isolated_filesystem(temp_dir=tmp_path):
+        result = CliRunner().invoke(main, ["init"], catch_exceptions=False)
+        starter = Path("jarify.toml").read_text()
+
+    assert result.exit_code == 0
+    assert "min_column_alias" in starter

--- a/tests/test_comment_overrides.py
+++ b/tests/test_comment_overrides.py
@@ -31,6 +31,28 @@ class TestOverrideParsing:
         assert overrides.config_for_line(config, 2).max_line_length == 200
         assert overrides.config_for_line(config, 4).max_line_length == 40
 
+    def test_set_min_column_alias_tracks_by_line(self):
+        overrides = parse_comment_overrides(
+            "-- jarify: set min-column-alias = 80\nSELECT 1 AS one, 22 AS two\n"
+            "-- jarify: reset min-column-alias\nSELECT 3 AS three, 44 AS four\n"
+        )
+
+        config = JarifyConfig(min_column_alias=64)
+        assert overrides.config_for_line(config, 2).min_column_alias == 80
+        assert overrides.config_for_line(config, 4).min_column_alias == 64
+
+    def test_set_min_column_alias_ignores_non_positive_values(self):
+        overrides = parse_comment_overrides("-- jarify: set min-column-alias = 0\nSELECT 1 AS one, 2 AS two\n")
+
+        config = JarifyConfig(min_column_alias=72)
+        assert overrides.config_for_line(config, 2).min_column_alias == 72
+
+    def test_set_min_column_alias_ignores_invalid_text_value(self):
+        overrides = parse_comment_overrides("-- jarify: set min-column-alias = nope\nSELECT 1 AS one, 2 AS two\n")
+
+        config = JarifyConfig(min_column_alias=72)
+        assert overrides.config_for_line(config, 2).min_column_alias == 72
+
 
 class TestLintOverrides:
     def test_disable_line_suppresses_inline_violation(self):
@@ -194,3 +216,28 @@ class TestFormatOverrides:
             in formatted
         )
         assert "if(\n" not in formatted
+
+    def test_set_min_column_alias_applies_to_following_statement(self):
+        sql = "-- jarify: set min-column-alias = 24\nSELECT a AS one, bb AS two FROM t"
+
+        formatted, _ = format_sql(sql)
+
+        alias_lines = [line for line in formatted.splitlines() if " AS " in line]
+        assert len({line.index(" AS ") for line in alias_lines}) == 1
+        assert alias_lines[0].index(" AS ") == 24
+
+    def test_reset_min_column_alias_restores_base_config_behavior(self):
+        sql = (
+            "-- jarify: set min-column-alias = 24\n"
+            "SELECT a AS one, bb AS two FROM t;\n"
+            "-- jarify: reset min-column-alias\n"
+            "SELECT c AS three, dd AS four FROM t"
+        )
+
+        formatted, _ = format_sql(sql)
+
+        alias_lines = [line for line in formatted.splitlines() if " AS " in line]
+        assert alias_lines[0].index(" AS ") == 24
+        assert alias_lines[1].index(" AS ") == 24
+        assert alias_lines[2].index(" AS ") < 24
+        assert alias_lines[3].index(" AS ") < 24

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,12 +21,14 @@ def test_default_config():
     assert config.leading_commas is True
     assert config.trailing_commas is False
     assert config.indent == 2
+    assert config.min_column_alias is None
 
 
 def test_config_from_dict():
-    config = JarifyConfig.from_dict({"indent": 4, "uppercase_keywords": False})
+    config = JarifyConfig.from_dict({"indent": 4, "uppercase_keywords": False, "min-column-alias": 80})
     assert config.indent == 4
     assert config.uppercase_keywords is False
+    assert config.min_column_alias == 80
 
 
 def test_find_config_walks_up(tmp_path: Path) -> None:
@@ -206,17 +208,18 @@ def test_config_from_dict_kebab_keys():
 
 def test_config_from_dict_mixed_case_keys():
     """Snake_case and kebab-case keys coexist without conflict."""
-    config = JarifyConfig.from_dict({"indent": 4, "no-unused-cte": "error"})
+    config = JarifyConfig.from_dict({"indent": 4, "no-unused-cte": "error", "min_column_alias": 72})
     assert config.indent == 4
     assert config.no_unused_cte == "error"
+    assert config.min_column_alias == 72
 
 
 def test_config_from_dict_does_not_mutate_input() -> None:
-    data = {"indent": 4, "rules": {"no_select_star": {"severity": "error"}}}
+    data = {"indent": 4, "min-column-alias": 80, "rules": {"no_select_star": {"severity": "error"}}}
 
     JarifyConfig.from_dict(data)
 
-    assert data == {"indent": 4, "rules": {"no_select_star": {"severity": "error"}}}
+    assert data == {"indent": 4, "min-column-alias": 80, "rules": {"no_select_star": {"severity": "error"}}}
 
 
 def test_merge_config_data_does_not_alias_inputs() -> None:
@@ -229,6 +232,12 @@ def test_merge_config_data_does_not_alias_inputs() -> None:
 
     assert base == {"rules": {"no_select_star": {"severity": "warn"}}}
     assert overlay == {"rules": {"no_unused_cte": {"severity": "off"}}}
+
+
+def test_min_column_alias_ignores_non_positive_values() -> None:
+    assert JarifyConfig(min_column_alias=0).min_column_alias is None
+    assert JarifyConfig(min_column_alias=-5).min_column_alias is None
+    assert JarifyConfig.from_dict({"min-column-alias": 0}).min_column_alias is None
 
 
 @pytest.mark.parametrize("command", ["fmt", "lint"])

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -4,6 +4,14 @@ from jarify.config import JarifyConfig
 from jarify.formatter import format_sql
 
 
+def _alias_positions(sql: str, *aliases: str) -> list[int]:
+    return [
+        line.index(" AS ")
+        for line in sql.splitlines()
+        if any(f" AS {alias}" in line for alias in aliases)
+    ]
+
+
 def test_format_simple_select():
     result, _ = format_sql("select 1")
     assert result.strip() != ""
@@ -49,9 +57,24 @@ def test_semicolon_own_line_multi_statement():
 def test_as_alignment():
     sql = "SELECT first_name AS first, last_name AS last, email AS email_address FROM t"
     result, _ = format_sql(sql)
-    lines = [line for line in result.splitlines() if " AS " in line]
-    as_positions = [line.index(" AS ") for line in lines]
+    as_positions = _alias_positions(result, "first", "last", "email_address")
     assert len(set(as_positions)) == 1, f"AS keywords not aligned: {as_positions}"
+
+
+def test_min_column_alias_pushes_aliases_to_configured_visible_column():
+    sql = "SELECT a AS one, bb AS two FROM t"
+    result, _ = format_sql(sql, JarifyConfig(min_column_alias=24))
+
+    as_positions = _alias_positions(result, "one", "two")
+    assert as_positions == [24, 24]
+
+
+def test_min_column_alias_does_not_shrink_longer_alignment():
+    sql = "SELECT a AS one, some_really_long_expression AS two FROM t"
+    baseline, _ = format_sql(sql)
+    result, _ = format_sql(sql, JarifyConfig(min_column_alias=12))
+
+    assert _alias_positions(result, "one", "two") == _alias_positions(baseline, "one", "two")
 
 
 def test_as_alignment_spans_ctes_and_outer_select():
@@ -61,13 +84,21 @@ def test_as_alignment_spans_ctes_and_outer_select():
         "SELECT q AS fifth, rr AS sixth FROM a JOIN b ON 1 = 1"
     )
     result, _ = format_sql(sql)
-    alias_lines = [
-        line
-        for line in result.splitlines()
-        if any(f" AS {alias}" in line for alias in ("first", "second", "third", "fourth", "fifth", "sixth"))
-    ]
-    as_positions = [line.index(" AS ") for line in alias_lines]
+    as_positions = _alias_positions(result, "first", "second", "third", "fourth", "fifth", "sixth")
     assert len(set(as_positions)) == 1, f"AS keywords not aligned across query: {as_positions}"
+
+
+def test_min_column_alias_applies_across_ctes_and_outer_select():
+    sql = (
+        "WITH a AS (SELECT x AS first, yy AS second FROM t), "
+        "b AS (SELECT zzz AS third, w AS fourth FROM u) "
+        "SELECT q AS fifth, rr AS sixth FROM a JOIN b ON 1 = 1"
+    )
+    result, _ = format_sql(sql, JarifyConfig(min_column_alias=28))
+
+    as_positions = _alias_positions(result, "first", "second", "third", "fourth", "fifth", "sixth")
+    assert len(set(as_positions)) == 1
+    assert as_positions[0] >= 28
 
 
 def test_as_alignment_stays_visually_consistent_across_nested_ctes():
@@ -85,24 +116,17 @@ def test_as_alignment_stays_visually_consistent_across_nested_ctes():
         "FROM outer_group JOIN sibling_group ON outer_one = sibling_one"
     )
     result, _ = format_sql(sql)
-    alias_lines = [
-        line
-        for line in result.splitlines()
-        if any(
-            f" AS {alias}" in line
-            for alias in (
-                "seed_one",
-                "seed_two",
-                "outer_one",
-                "outer_two",
-                "sibling_one",
-                "sibling_two",
-                "final_one",
-                "final_two",
-            )
-        )
-    ]
-    as_positions = [line.index(" AS ") for line in alias_lines]
+    as_positions = _alias_positions(
+        result,
+        "seed_one",
+        "seed_two",
+        "outer_one",
+        "outer_two",
+        "sibling_one",
+        "sibling_two",
+        "final_one",
+        "final_two",
+    )
     assert len(set(as_positions)) == 1, f"Nested CTE alias alignment drifted: {as_positions}"
 
 
@@ -292,6 +316,17 @@ class TestFromFirst:
         )
         assert "      id + 1         AS vendor_id\n     ,name || suffix AS vendor_name" in out
         assert "      id   AS vendor_id\n     ,name AS vendor_name" in out
+
+    def test_modified_star_respects_min_column_alias(self):
+        out, _ = format_sql(
+            "SELECT * REPLACE (id AS vendor_id, name AS vendor_name) "
+            "RENAME (id AS display_id, name AS display_name) FROM vendors",
+            JarifyConfig(min_column_alias=24),
+        )
+
+        replace_rename_lines = [line for line in out.splitlines() if " AS vendor_" in line or " AS display_" in line]
+        assert len({line.index(" AS ") for line in replace_rename_lines}) == 1
+        assert replace_rename_lines[0].index(" AS ") == 24
 
 
 class TestLeftOuterJoinNormalization:


### PR DESCRIPTION
> [!NOTE]
> This PR description was authored by OpenAI API assistant (gpt-5.4) on behalf of @johnallen3d.

## Summary

Add `min-column-alias` so teams can set a minimum visible column for SELECT alias alignment while still letting longer expressions push aliases farther right.

This also adds `-- jarify: set min-column-alias = ...` and `-- jarify: reset min-column-alias` for file- or region-specific overrides without changing project-wide config.

## Why

Issue #325 asked for a simpler alternative to visual guide intervals: one minimum alias column that acts as a floor instead of replacing the current longest-expression alignment behavior.

Resolves #325
